### PR TITLE
Add version option to cli and dynamic versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,8 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry-dynamic-versioning]
 enable = true
+vcs = "git"
+style = "pep440"
 
 [tool.poetry.scripts]
 schemauto = "schema_automator.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,11 @@ lxml = ">=4.9.1"
 llm = ">=0.12"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.poetry-dynamic-versioning]
+enable = true
 
 [tool.poetry.scripts]
 schemauto = "schema_automator.cli:main"

--- a/schema_automator/__init__.py
+++ b/schema_automator/__init__.py
@@ -1,3 +1,11 @@
+from importlib import metadata
+
 from schema_automator.annotators import *
 from schema_automator.importers import *
 from schema_automator.generalizers import *
+
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    # package is not installed
+    __version__ = "0.0.0"  # pragma: no cover

--- a/schema_automator/cli.py
+++ b/schema_automator/cli.py
@@ -33,6 +33,7 @@ from schema_automator.importers.rdfs_import_engine import RdfsImportEngine
 from schema_automator.importers.sql_import_engine import SqlImportEngine
 from schema_automator.importers.tabular_import_engine import TableImportEngine
 from schema_automator.utils.schemautils import write_schema
+from schema_automator import __version__
 
 input_option = click.option(
     "-i",
@@ -80,6 +81,7 @@ enum_threshold_option = click.option('--enum-threshold', default=0.1, help='if t
               help="Set the level of verbosity")
 @click.option("-q", "--quiet",
               help="Silence all diagnostics")
+@click.version_option(__version__, "-V", "--version")
 def main(verbose: int, quiet: bool):
     """Run the LinkML Schema Automator Command Line.
 


### PR DESCRIPTION
I noticed that the `schemauto` command had no `--version` option.

This adds the option and sets up [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning) as in linkML.