### PR TITLE
Doc fixes & more metadata in pyproject for PyPI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ For running tests, we use `pytest`.
 ## Discussion
 
 If you run into any issues or find certain functionality not documented/explained properly then feel free to 
-raise a ticket in the project's [issue tracker](https://github.com/linkml/issues). 
+raise a ticket in the project's [issue tracker](https://github.com/linkml/schema-automator/issues). 
 There are issue templates to capture certain types of issues.
 
 ## First Time Contributors
@@ -73,7 +73,7 @@ with a 'Do Not Merge' label.
 ## How to Report a Bug
 
 We recommend making a new ticket for each bug that you encounter while working with KGX. Please be sure to provide
-sufficient context for a bug you are reporting. There are [Issue Templates](https://github.com/linkml/issues/new/choose) 
+sufficient context for a bug you are reporting. There are [Issue Templates](https://github.com/linkml/schema-automator/issues/new/choose) 
 that you can use as a starting point.
 
 ## How to Request an Enhancement

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,24 +1,24 @@
-.. cli:
+.. _cli:
 
-Command Line
-============
+Command Line Interface
+======================
 
-All Schema Automator functionality is available via the ``schemauto`` command
+All Schema Automator functionality is available via the ``schemauto`` command.
 
 Preamble
 --------
 
-.. warning ::
+.. warning::
 
    Previous versions had specific commands like ``tsv2linkml`` these are now deprecated.
    Instead these are now *subcommands* of the main ``schemauto`` command, and have been renamed.
 
-.. note ::
+.. note::
 
    we follow the `CLIG <https://clig.dev/>`_ guidelines as far as possible
 
 Main commands
----------
+-------------
 
 .. currentmodule:: schema_automator.cli
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,11 +3,13 @@ LinkML Schema Automator
 
 Schema Automator is a toolkit for bootstrapping and automatically enhancing schemas from a variety of sources.
 
+The project is open source (BSD 3-clause license) and hosted on `GitHub <https://github.com/linkml/schema-automator>`_.
+
 Use cases include:
 
 1. Inferring an initial schema or data dictionary from a dataset that is a collection of TSVs
 2. Automatically annotating schema elements and enumerations using the BioPortal annotator
-3. Importing from a language like RDFS/OWL
+3. Importing from a language like RDFS/OWL/SQL
 
 The primary output of Schema Automator is a `LinkML Schema <https://linkml.io/linkml>`_. This can be converted to other
 schema frameworks, including:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 LinkML Schema Automator
-============================================
+=======================
 
 Schema Automator is a toolkit for bootstrapping and automatically enhancing schemas from a variety of sources.
 
@@ -25,7 +25,6 @@ schema frameworks, including:
    :maxdepth: 3
    :caption: Contents:
 
-   index
    introduction
    install
    cli

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,8 +1,8 @@
 Installation
-======
+============
 
 Direct Installation
-------------
+-------------------
 
 ``schema-automator`` and its components require Python 3.9 or greater.
 
@@ -17,7 +17,7 @@ To check this works:
    schemauto --help
 
 Running via Docker
-------------
+------------------
 
 You can use the `Schema Automator Docker Container <https://hub.docker.com/r/linkml/schema-automator>`_
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,7 +1,5 @@
-.. _introduction:
-
 Introduction
-=======================
+============
 
 This is a toolkit that assists with generating and enhancing schemas and data models from a variety
 of sources.
@@ -9,7 +7,7 @@ of sources.
 The primary end target is a `LinkML <https://linkml.io>`_ schema, but the framework can be used
 to generate JSON-Schema, SHACL, SQL DDL etc via the `LinkML Generator <https://linkml.io/linkml/generators>`_ framework.
 
-All functionality is available via a :ref:`cli`. In future there will be a web-based interface.
+All functionality is available via a :ref:`CLI <cli>`. In future there will be a web-based interface.
 The functionality is also available by using the relevant Python :ref:`packages`.
 
 Generalization from Instance Data
@@ -24,7 +22,7 @@ Generalizers allow you to *bootstrap* a schema by generalizing from existing dat
 * RDF instance graphs
 
 Importing from alternative modeling frameworks
----------------------------------
+----------------------------------------------
 
 See :ref:`importers`
 
@@ -35,7 +33,7 @@ See :ref:`importers`
 In future other frameworks will be supported
 
 Annotating schemas
----------------------------------
+------------------
 
 See :ref:`annotators`
 
@@ -46,7 +44,7 @@ Annotators to provide ways to automatically add metadata to your schema, includi
 * Annotate using Large Language Models (LLMs)
 
 General Utilities
----------------------------------
+-----------------
 
-See :ref:`utilitiess`
+See :ref:`utilities`
 

--- a/docs/metamodels/index.rst
+++ b/docs/metamodels/index.rst
@@ -8,16 +8,6 @@ metamodels in order to define transformations.
    :maxdepth: 3
    :caption: Contents:
 
-   index
    cadsr/index
    frictionless/index
    dosdp/index
-   fhir/index
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/docs/packages/annotators.rst
+++ b/docs/packages/annotators.rst
@@ -1,7 +1,5 @@
-.. annotators:
-
 Annotators
-=========
+==========
 
 Importers take an existing schema and *annotate* it with information
 

--- a/docs/packages/generalizers.rst
+++ b/docs/packages/generalizers.rst
@@ -1,7 +1,5 @@
-.. generalizers:
-
 Generalizers
-=========
+============
 
 Generalizers take example data and *generalizes* to a schema
 
@@ -11,7 +9,7 @@ Generalizers take example data and *generalizes* to a schema
    that *semi*-automates the creation of a new schema for you.
 
 Generalizing from a single TSV
------------------
+------------------------------
 
 .. code-block::
 
@@ -92,7 +90,7 @@ Enums will be automatically inferred:
 
 
 Generalizing from multiple TSVs
-------------
+-------------------------------
 
 You can use the ``generalize-tsvs`` command to generalize from *multiple* TSVs, with
 foreign key linkages auto-inferred.
@@ -161,7 +159,7 @@ slots:
     range: string
 
 Generalizing from tables on the web
------------------
+-----------------------------------
 
 You can use ``generalize-htmltable``
 
@@ -218,12 +216,12 @@ Will generate:
         - TWAS P value
 
 Generalizing from JSON
------------
+----------------------
 
 tbw
 
 Chaining an annotator
------------------
+---------------------
 
 If you provide an ``--annotator`` option you can auto-annotate enums:
 
@@ -279,8 +277,8 @@ The annotation can also be run as a separate step
 
 See :ref:`annotators`
 
-Packages
---------
+Packages for generalizing
+-------------------------
 
 .. currentmodule:: schema_automator.generalizers
 

--- a/docs/packages/generalizers.rst
+++ b/docs/packages/generalizers.rst
@@ -90,62 +90,6 @@ Enums will be automatically inferred:
           Lowland Black Spruce:
             description: Lowland Black Spruce
 
-Chaining an annotator
------------------
-
-If you provide an ``--annotator`` option you can auto-annotate enums:
-
-.. code-block::
-
-    schemauto  generalize-csv \
-        --annotator bioportal:envo \
-        tests/resources/NWT_wildfires_biophysical_2016.tsv \
-        -o wildfire.yaml
-
-.. code-block:: yaml
-
-      ecosystem_enum:
-        from_schema: https://w3id.org/MySchema
-        permissible_values:
-          Open Fen:
-            description: Open Fen
-            meaning: ENVO:00000232
-            exact_mappings:
-            - ENVO:00000232
-          Treed Fen:
-            description: Treed Fen
-            meaning: ENVO:00000232
-            exact_mappings:
-            - ENVO:00000232
-          Black Spruce:
-            description: Black Spruce
-          Poor Fen:
-            description: Poor Fen
-            meaning: ENVO:00000232
-            exact_mappings:
-            - ENVO:00000232
-          Fen:
-            description: Fen
-            meaning: ENVO:00000232
-          Lowland:
-            description: Lowland
-          Upland:
-            description: Upland
-            meaning: ENVO:00000182
-          Bog:
-            description: Bog
-            meaning: ENVO:01000534
-            exact_mappings:
-            - ENVO:01000535
-            - ENVO:00000044
-            - ENVO:01001209
-            - ENVO:01000527
-          Lowland Black Spruce:
-            description: Lowland Black Spruce
-
-The annotation can also be run as a separate step
-
-See :ref:`annotators`
 
 Generalizing from multiple TSVs
 ------------
@@ -276,7 +220,64 @@ Will generate:
 Generalizing from JSON
 -----------
 
+tbw
 
+Chaining an annotator
+-----------------
+
+If you provide an ``--annotator`` option you can auto-annotate enums:
+
+.. code-block::
+
+    schemauto  generalize-csv \
+        --annotator bioportal:envo \
+        tests/resources/NWT_wildfires_biophysical_2016.tsv \
+        -o wildfire.yaml
+
+.. code-block:: yaml
+
+      ecosystem_enum:
+        from_schema: https://w3id.org/MySchema
+        permissible_values:
+          Open Fen:
+            description: Open Fen
+            meaning: ENVO:00000232
+            exact_mappings:
+            - ENVO:00000232
+          Treed Fen:
+            description: Treed Fen
+            meaning: ENVO:00000232
+            exact_mappings:
+            - ENVO:00000232
+          Black Spruce:
+            description: Black Spruce
+          Poor Fen:
+            description: Poor Fen
+            meaning: ENVO:00000232
+            exact_mappings:
+            - ENVO:00000232
+          Fen:
+            description: Fen
+            meaning: ENVO:00000232
+          Lowland:
+            description: Lowland
+          Upland:
+            description: Upland
+            meaning: ENVO:00000182
+          Bog:
+            description: Bog
+            meaning: ENVO:01000534
+            exact_mappings:
+            - ENVO:01000535
+            - ENVO:00000044
+            - ENVO:01001209
+            - ENVO:01000527
+          Lowland Black Spruce:
+            description: Lowland Black Spruce
+
+The annotation can also be run as a separate step
+
+See :ref:`annotators`
 
 Packages
 --------

--- a/docs/packages/importers.rst
+++ b/docs/packages/importers.rst
@@ -1,5 +1,3 @@
-.. importers:
-
 Importers
 =========
 
@@ -15,7 +13,7 @@ Importers are the opposite of `Generators <https://linkml.io/linkml/generators/i
    will be created.
 
 Importing from JSON-Schema
----------
+--------------------------
 
 The ``import-json-schema`` command can be used:
 
@@ -24,7 +22,7 @@ The ``import-json-schema`` command can be used:
     schemauto import-json-schema tests/resources/model_card.schema.json
 
 Importing from Kwalify
----------
+----------------------
 
 The ``import-kwalify`` command can be used:
 
@@ -33,7 +31,7 @@ The ``import-kwalify`` command can be used:
     schemauto import-kwalify tests/resources/test.kwalify.yaml
 
 Importing from OWL
----------
+------------------
 
 You can import from a schema-style OWL ontology. This must be in functional syntax
 
@@ -45,7 +43,7 @@ Use robot to convert ahead of time:
     schemauto import-owl schemaorg.ofn
 
 Importing from SQL
----------
+------------------
 
 You can import a schema from a SQL database
 
@@ -65,7 +63,7 @@ For example, for the `RNA Central public database <https://rnacentral.org/help/p
     schemauto import-sql postgresql+psycopg2://reader:NWDMCE5xdipIjRrp@hh-pgsql-public.ebi.ac.uk:5432/pfmegrnargs
 
 Importing from caDSR
----------
+--------------------
 
 caDSR is an ISO-11179 compliant metadata registry. The ISO-11179 conceptual model can be mapped to LinkML. The
 canonical mapping maps a CDE onto a LinkML *slot*.
@@ -79,8 +77,8 @@ NCI implements a JSON serialization of ISO-11197. You can import this JSON and c
     schemauto import-cadsr "cdes/*.json"
 
 
-Packages
--------
+Packages for importing
+----------------------  
 
 .. currentmodule:: schema_automator.importers
 

--- a/docs/packages/index.rst
+++ b/docs/packages/index.rst
@@ -10,3 +10,4 @@ The code is organized into different python *packages*
    importers
    generalizers
    annotators
+   utilities

--- a/docs/packages/index.rst
+++ b/docs/packages/index.rst
@@ -1,5 +1,3 @@
-.. packages:
-
 Packages
 ========
 

--- a/docs/packages/utilities.rst
+++ b/docs/packages/utilities.rst
@@ -1,5 +1,3 @@
-.. utilities:
-
 Utilities
 =========
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,27 @@ description = "Infer models, enrich with meaning for terms including enum permis
 authors = ["Chris Mungall", "Mark Miller", "Sierra Moxon", "Harshad Hegde"]
 license = "BSD 3-Clause"
 readme = "README.md"
+requires-python = ">=3.9"
+
+keywords = ["schema", "linked data", "data modeling", "rdf", "owl"]
+
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Programming Language :: Python",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Healthcare Industry",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+]
+
+repository = "https://github.com/linkml/schema-automator/"
+documentation = "https://linkml.io/schema-automator/"
 
 packages = [
     { include = "schema_automator" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Infer models, enrich with meaning for terms including enum permis
 authors = ["Chris Mungall", "Mark Miller", "Sierra Moxon", "Harshad Hegde"]
 license = "BSD 3-Clause"
 readme = "README.md"
-requires-python = ">=3.9"
 
 keywords = ["schema", "linked data", "data modeling", "rdf", "owl"]
 

--- a/schema_automator/cli.py
+++ b/schema_automator/cli.py
@@ -129,7 +129,7 @@ def generalize_tsv(tsvfile, output, class_name, schema_name, pandera: bool, anno
 
     Example:
 
-        schemauto generalize-tsv --class-name Person --schema-name PersonInfo my/data/persons.tsv
+        ``schemauto generalize-tsv --class-name Person --schema-name PersonInfo my/data/persons.tsv``
     """
     kwargs = {k:v for k, v in kwargs.items() if v is not None}
     if pandera:
@@ -161,11 +161,11 @@ def generalize_tsvs(tsvfiles, output, schema_name, **kwargs):
 
     See :ref:`generalizers` for more on the generalization framework
 
-    This uses :ref:`CsvDataGeneralizer.convert_multiple`
+    This uses CsvDataGeneralizer.convert_multiple
 
     Example:
 
-        schemauto generalize-tsvs --class-name Person --schema-name PersonInfo my/data/*.tsv
+        ``schemauto generalize-tsvs --class-name Person --schema-name PersonInfo my/data/*.tsv``
     """
     ie = CsvDataGeneralizer(**kwargs)
     schema = ie.convert_multiple(tsvfiles, schema_name=schema_name)
@@ -229,7 +229,7 @@ def import_dosdps(dpfiles, output, **args):
 
     Example:
 
-        schemauto import-dosdps --range-as-enums patterns/*yaml -o my-schema.yaml
+        ``schemauto import-dosdps --range-as-enums patterns/*.yaml -o my-schema.yaml``
     """
     ie = DOSDPImportEngine()
     schema = ie.convert(dpfiles, **args)
@@ -309,7 +309,7 @@ def generalize_json(input, output, schema_name, depluralize: bool, format, omit_
 
     Example:
 
-        schemauto generalize-json my/data/persons.json -o my.yaml
+        ``schemauto generalize-json my/data/persons.json -o my.yaml``
     """
     ie = JsonDataGeneralizer(omit_null=omit_null, depluralize_class_names=depluralize)
     if inlined_map:
@@ -336,7 +336,7 @@ def generalize_toml(input, output, schema_name, omit_null, **kwargs):
 
     Example:
 
-        schemauto generalize-toml my/data/conf.toml -o my.yaml
+        ``schemauto generalize-toml my/data/conf.toml -o my.yaml``
     """
     ie = JsonDataGeneralizer(omit_null=omit_null)
     schema = ie.convert(input, format='toml', **kwargs)
@@ -365,7 +365,7 @@ def import_json_schema(input, output, import_project: bool, schema_name, format,
 
     Example:
 
-        schemauto import-json-schema my/schema/personinfo.schema.json
+        ``schemauto import-json-schema my/schema/personinfo.schema.json``
     """
     ie = JsonSchemaImportEngine(**kwargs)
     if not import_project:
@@ -390,7 +390,7 @@ def import_kwalify(input, output, schema_name, **kwargs):
 
     Example:
 
-        schemauto import-kwalify my/schema/personinfo.kwalify.yaml
+        ``schemauto import-kwalify my/schema/personinfo.kwalify.yaml``
     """
     ie = KwalifyImportEngine(**kwargs)
     schema = ie.convert(input, output, name=schema_name, format=format)
@@ -409,7 +409,7 @@ def import_frictionless(input, output, schema_name, schema_id, **kwargs):
 
     Example:
 
-        schemauto import-frictionless cfde.package.json
+        ``schemauto import-frictionless cfde.package.json``
     """
     ie = FrictionlessImportEngine(**kwargs)
     schema = ie.convert(input, name=schema_name, id=schema_id)
@@ -429,7 +429,7 @@ def import_cadsr(input, output, schema_name, schema_id, **kwargs):
 
     Example:
 
-        schemauto import-cadsr "cdes/*.json"
+        ``schemauto import-cadsr "cdes/*.json"``
     """
     ie = CADSRImportEngine()
     paths = [str(gf.absolute())  for gf in Path().glob(input) if gf.is_file()]
@@ -460,7 +460,7 @@ def import_owl(owlfile, output, **args):
 
     Example:
 
-        schemauto import-owl prov.ofn -o my.yaml
+        ``schemauto import-owl prov.ofn -o my.yaml``
     """
     sie = OwlImportEngine()
     schema = sie.convert(owlfile, **args)
@@ -509,7 +509,7 @@ def generalize_rdf(rdffile, dir, output, **args):
 
     Example:
 
-        schemauto generalize-rdf my/data/persons.ttl
+        ``schemauto generalize-rdf my/data/persons.ttl``
     """
     sie = RdfDataGeneralizer()
     if not os.path.exists(dir):
@@ -539,13 +539,13 @@ def annotate_schema(schema: str, input: str, output: str, **kwargs):
     
     Example:
     
-        schemauto annotate-schema -i bioportal: my-schema.yaml -o annotated.yaml
+        ``schemauto annotate-schema -i bioportal: my-schema.yaml -o annotated.yaml``
         
     This will require you setting the API key via OAK - see OAK docs.
         
     You can specify a specific ontology
     
-        schemauto annotate-schema -i bioportal:ncbitaxon my-schema.yaml -o annotated.yaml
+        ``schemauto annotate-schema -i bioportal:ncbitaxon my-schema.yaml -o annotated.yaml``
 
     In future OAK will support a much wider variety of annotators including:
     
@@ -594,13 +594,13 @@ def enrich_using_ontology(schema: str, input: str, output: str, annotate: bool, 
 
     Example:
 
-        schemauto enrich-using-ontology -i bioportal: my-schema.yaml -o my-enriched.yaml
+        ``schemauto enrich-using-ontology -i bioportal: my-schema.yaml -o my-enriched.yaml``
 
     If your schema has no mappings you can use --annotate to add them
 
     Example:
 
-        schemauto enrich-using-ontology -i so.obo --annotate my-schema.yaml -o my-enriched.yaml --annotate
+        ``schemauto enrich-using-ontology -i so.obo --annotate my-schema.yaml -o my-enriched.yaml --annotate``
     """
     impl = get_implementation_from_shorthand(input)
     annr = SchemaAnnotator(impl)
@@ -630,7 +630,7 @@ def enrich_using_llm(schema: str, model: str, output: str, **args):
 
     Example:
 
-        pip install schema-automator[llm]
+        ``pip install schema-automator[llm]``
 
     """
     logging.info(f"Enriching: {schema}")

--- a/schema_automator/generalizers/csv_data_generalizer.py
+++ b/schema_automator/generalizers/csv_data_generalizer.py
@@ -118,9 +118,9 @@ class CsvDataGeneralizer(Generalizer):
 
         This procedure can generate false positives, so additional heuristics are applied. Each potential
         foreign key relationship gets an ad-hoc score:
-         - links across tables score more highly than within
-         - suffixes such as _id are more likely on PK and FK tables
-         - the foreign key column table is likely to start with the base column name
+        - links across tables score more highly than within
+        - suffixes such as _id are more likely on PK and FK tables
+        - the foreign key column table is likely to start with the base column name
         In addition, if there are competing primary keys for a table, the top scoring one is selected
         """
         fks: List[ForeignKey] = []

--- a/schema_automator/importers/__init__.py
+++ b/schema_automator/importers/__init__.py
@@ -2,4 +2,4 @@ from schema_automator.importers.jsonschema_import_engine import JsonSchemaImport
 from schema_automator.importers.owl_import_engine import OwlImportEngine
 from schema_automator.importers.dosdp_import_engine import DOSDPImportEngine
 from schema_automator.importers.frictionless_import_engine import FrictionlessImportEngine
-
+from schema_automator.importers.cadsr_import_engine import CADSRImportEngine

--- a/schema_automator/importers/jsonschema_import_engine.py
+++ b/schema_automator/importers/jsonschema_import_engine.py
@@ -35,7 +35,7 @@ def json_schema_from_open_api(oa: Dict) -> Dict:
 @dataclass
 class JsonSchemaImportEngine(ImportEngine):
     """
-    A :ref:`ImportEngine` that imports a JSON-Schema representation to a LinkML Schema
+    An ImportEngine that imports a JSON-Schema representation to a LinkML Schema
     """
     use_attributes: bool = False
     is_openapi: bool = False


### PR DESCRIPTION
This updates `pyproject.toml`. After the next release PyPi should show the links to this repo and the docs. I also added classifiers which are based on the ones used in LinkML.

The starting page of the docs has now also a link to the repo. While building the docs locally, I noticed some error in the Sphinx-build log. I fixed the errors and most warnings except those related to the generated docs of the metamodels.

Closes #146