### PR TITLE
Add canonical data dictionary format spec (closes #191)

### DIFF
--- a/docs/data_dictionary_format.rst
+++ b/docs/data_dictionary_format.rst
@@ -130,13 +130,27 @@ imply including ``required``.
        LinkML's ``slot_uri`` for the emitted slot.
    * - ``see_also``
      - External references — codebooks, study protocols, standards.
-       Multivalued; in TSV form, multiple values are pipe-separated within
-       a single cell.
+       Multivalued in TSV form: see "Multivalued TSV cells" below.
    * - ``example_values``
      - Sample values for this column. Useful as authoring guidance for
        consumers and as a fallback signal for pattern inference when
-       ``pattern`` is not provided. Multivalued; in TSV form, multiple
-       values are pipe-separated within a single cell.
+       ``pattern`` is not provided. Multivalued in TSV form: see
+       "Multivalued TSV cells" below.
+
+Multivalued TSV cells
+~~~~~~~~~~~~~~~~~~~~~
+
+Multivalued Spec B fields (``see_also``, ``example_values``) encode
+multiple values pipe-separated within a single cell, using the same
+convention as the ``codes`` field. Whitespace around the ``|`` separator
+is trimmed; the values themselves are kept verbatim. If a value contains
+a literal pipe, escape it as ``\|`` (same rule as in codes).
+
+Example (a ``see_also`` cell)::
+
+    LOINC:2160-0 | https://example.org/protocol.pdf
+
+In YAML form, multivalued fields are written as plain YAML lists.
 
 Type vocabulary
 ---------------
@@ -209,8 +223,8 @@ Examples::
 Escaping
 ~~~~~~~~
 
-To include a literal ``,``, ``|``, or ``\`` in a code, prefix it with a
-backslash:
+To include a literal comma, pipe, or backslash in a code, prefix it with
+a backslash:
 
 - ``\,`` — literal comma
 - ``\|`` — literal pipe
@@ -384,7 +398,6 @@ extensions to *this* format in future revisions:
   referencing it from multiple ``permissible_values`` columns).
 - A ``format`` field for refining types (``string`` + ``format: email``,
   date format strings, etc.).
-- Escaping for ``|`` and ``,`` in code values.
 - Document-level metadata and file-level conventions.
 
 Examples

--- a/docs/data_dictionary_format.rst
+++ b/docs/data_dictionary_format.rst
@@ -322,7 +322,7 @@ scope:
   ``old_name`` in v3," "valid from 2020-01 to 2023-06," provenance chains.
   Versioning concerns belong at the dataset/schema level, not per-row.
 
-- **Cross-column constraints.** Conditional requireds, dependencies
+- **Cross-column constraints.** Conditional required-fields, dependencies
   ("field A is required only if field B is X"), value relationships
   across columns. The general case needs a real expression language, not
   a small format extension.

--- a/docs/data_dictionary_format.rst
+++ b/docs/data_dictionary_format.rst
@@ -8,7 +8,8 @@ This is a forward-looking, prescriptive target spec. The audience is a data
 owner at a *new* study, preparing their data for sharing, before any
 inconsistent local conventions have set in. Handling of legacy or messy
 data dictionaries is a separate concern; those are normalized into this
-format by an upstream layer (see :ref:`linkml/schema-automator#200`).
+format by an upstream layer (see `linkml/schema-automator#200
+<https://github.com/linkml/schema-automator/issues/200>`_).
 
 Goals
 -----
@@ -244,19 +245,107 @@ adds coupling, filename encoding that's fragile to parse) has worse
 trade-offs than dropping document-level metadata entirely. If a future
 revision adds it, the substrate decision will need to be revisited.
 
+Relationship to existing formats
+--------------------------------
+
+Across communities, real-world data dictionaries converge on a small core:
+**name, description, and (sometimes, partially) type information**. That
+common ground is what nearly every author actually writes, regardless of
+which format they nominally produce. This spec is a deliberately small
+extension of that core — adding the structure needed to validate and
+enrich, while staying close to what people already draft in the wild.
+
+The flat-file shape is a deliberate alignment, not an oversight. Every
+format below (with the partial exception of XML codebook standards) starts
+from row-per-variable, columns-of-attributes. That's how data dictionaries
+naturally exist in researcher hands — a spreadsheet, a CSV, a few columns
+deep. Adding hierarchy, sidecar files, or required tooling would make
+authoring harder *and* make conversion from existing formats harder. We
+chose simplicity at this layer in exchange for keeping the
+existing-format-to-this-format adapters tractable.
+
+We are implementing the core of the formats listed below. If our spec ever
+diverges substantially from that core, that's a signal we've over-rotated
+on novelty and should re-examine the divergence rather than ship it.
+
+**Frictionless Table Schema** (data.gov, OpenML, the ``datasets`` package).
+Our type vocabulary is a researcher-comprehensible subset of Frictionless's;
+``pattern`` and per-column structure align directly. Where we diverge: we
+treat enumerated values as a primary type (``permissible_values``) rather
+than a string-with-enum-constraint, matching how researchers think about
+multiple-choice columns. We intend to ship a Frictionless adapter
+(translator in both directions).
+
+**REDCap data dictionary** (de facto standard in clinical research). Our
+codes encoding (``code, label | code, label | ...`` with bareword
+shorthand) is taken directly from REDCap. Our type-as-major-axis approach
+mirrors REDCap's Field Type. We diverge by collapsing REDCap's UI-flavored
+types (``radio``, ``dropdown``, ``checkbox``) into the single semantic
+type ``permissible_values`` — a data dictionary describes data, not the
+form widget that produced it. We intend to ship a REDCap adapter.
+
+**SchemaSheets** (LinkML community). This format supersedes SchemaSheets
+for the data-dictionary use case. Where SchemaSheets requires authors to
+work with LinkML conventions (slot/class distinctions, slot URIs, mixin
+semantics), we present a researcher-comprehensible flat surface.
+SchemaSheets capabilities not directly expressible here will be addressed
+during the migration period. A SchemaSheets adapter is part of the
+planned tooling.
+
+**DDI / CDISC** (heavyweight institutional standards). These describe a
+different scope — full study lifecycle, regulatory submission. Not
+displaced; complementary in cases where they apply.
+
+Out of scope
+------------
+
+This format intentionally covers a single, flat tabular dataset described
+by a single data dictionary. The following use cases need a higher-order
+artifact on top of, or alongside, this format, and are explicitly out of
+scope:
+
+- **Hierarchical or nested data.** Columns containing JSON-shaped
+  structures, repeated groups, document trees. Authoring as a flat
+  row-per-column descriptor doesn't fit. Use a structured data model
+  (LinkML class definitions, JSON Schema, Avro) for the nesting and
+  reference this format for leaf-level columns where applicable.
+
+- **Multi-table datasets with relationships.** Several related tables
+  sharing keys (e.g., dbGaP's phs/pht/phv structure, relational
+  databases). Each table can have its own data dictionary in this format,
+  but the relational structure between them — foreign keys, joins, shared
+  dimensions — is the job of a higher-order schema artifact. A simple
+  manifest pattern (a list of data dictionaries plus a relations file)
+  would address this without burdening per-DD authoring.
+
+- **Variable versioning and lineage.** "This variable was renamed from
+  ``old_name`` in v3," "valid from 2020-01 to 2023-06," provenance chains.
+  Versioning concerns belong at the dataset/schema level, not per-row.
+
+- **Cross-column constraints.** Conditional requireds, dependencies
+  ("field A is required only if field B is X"), value relationships
+  across columns. The general case needs a real expression language, not
+  a small format extension.
+
+- **Domain-specific metadata.** Clinical (codeset versions, encounter
+  types), survey (question wording, branching logic), environmental
+  (sensor calibration, measurement uncertainty). The format is
+  intentionally domain-naive. Domain extensions can live in optional
+  Spec B columns by convention, but defining them is the responsibility
+  of domain communities, not this spec.
+
 Future revisions
 ----------------
 
-The following are explicitly deferred from v1:
+The following are deferred from v1 but may be added as small additive
+extensions to *this* format in future revisions:
 
 - Named, reusable enum definitions (e.g., declaring an enum once and
   referencing it from multiple ``permissible_values`` columns).
 - A ``format`` field for refining types (``string`` + ``format: email``,
   date format strings, etc.).
 - Escaping for ``|`` and ``,`` in code values.
-- Cross-column constraints (conditional requireds, dependencies).
 - Document-level metadata and file-level conventions.
-- Per-variable provenance, lineage, and versioning.
 
 Examples
 --------

--- a/docs/data_dictionary_format.rst
+++ b/docs/data_dictionary_format.rst
@@ -1,0 +1,268 @@
+Data Dictionary Format
+======================
+
+Schema Automator's canonical data dictionary format — the format we ask
+new studies to produce when they're onboarding to a data-sharing pipeline.
+
+This is a forward-looking, prescriptive target spec. The audience is a data
+owner at a *new* study, preparing their data for sharing, before any
+inconsistent local conventions have set in. Handling of legacy or messy
+data dictionaries is a separate concern; those are normalized into this
+format by an upstream layer (see :ref:`linkml/schema-automator#200`).
+
+Goals
+-----
+
+The format provides enough computable information for Schema Automator to
+produce maximally-enriched LinkML schemas, while staying simple enough that
+any researcher — clinical, environmental, social, business — can author and
+maintain it without specialized tooling. The format is row-per-variable and
+deliberately minimal.
+
+Substrate
+---------
+
+The recommended substrate is **TSV (tab-separated values)**. CSV is also
+accepted; tabs avoid quoting issues when code values contain commas.
+
+A YAML form is sanctioned for tooling-friendly authoring (e.g., schema
+emission, programmatic generation). YAML and TSV are equivalent — the same
+set of rows, the same fields, the same conformance rules. Tooling consumes
+either.
+
+The canonical machine-readable definition is the LinkML schema at
+``schema_automator/metamodels/data_dictionary.yaml``.
+
+Two specs
+---------
+
+The format is structured as two specs:
+
+**Spec A** is the recommended set of fields. This is what we ask researchers
+to produce.
+
+**Spec B** is a set of optional columns that researchers may add
+independently. Adopting one Spec B column does not require adopting any
+other; tooling consumes whichever optional fields are present and ignores
+the rest.
+
+Spec A: recommended fields
+---------------------------
+
+Each row of a data dictionary describes one column of the data file.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 20 65
+
+   * - Field
+     - When required
+     - Description
+   * - ``name``
+     - Always
+     - Column name as it appears in the data file. Accepts a string
+       identifier or a URI/CURIE; URI/CURIE forms are preferred when the
+       column has a known semantic identity in a controlled vocabulary.
+   * - ``type``
+     - Best-practice required
+     - Data type from the canonical type vocabulary (see below).
+   * - ``description``
+     - Best-practice required
+     - Prose description of what the variable represents. **Must not
+       contain code lists, unit declarations, value ranges, or example
+       values** — those have dedicated fields.
+   * - ``codes``
+     - When ``type`` is ``permissible_values``
+     - The permissible values for this column, encoded as
+       ``code, label | code, label | ...``. Bareword shorthand is
+       allowed: a token without a comma is interpreted as
+       ``value, value``.
+   * - ``unit``
+     - When ``type`` is ``integer`` or ``decimal``
+     - Unit of measure. Use the literal token ``none`` for genuinely
+       unitless quantities (counts, ratios). UCUM units are encouraged
+       but not required; freeform reasonable units (``mg/dL``,
+       ``servings/week``) are accepted.
+   * - ``min``
+     - When ``type`` is ``integer`` or ``decimal``
+     - Minimum permissible value. Use ``none`` for genuinely unbounded
+       variables.
+   * - ``max``
+     - When ``type`` is ``integer`` or ``decimal``
+     - Maximum permissible value. Use ``none`` for genuinely unbounded
+       variables.
+
+The ``none`` token is distinct from an empty cell. An empty cell means the
+author has not declared the field and is reported as a conformance issue.
+``none`` is the explicit declaration that the field is genuinely not
+applicable.
+
+Spec B: optional columns
+-------------------------
+
+Researchers may add any subset of the following columns to a data
+dictionary. Each is independently adoptable — including ``label`` does not
+imply including ``required``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 82
+
+   * - Field
+     - Description
+   * - ``label``
+     - Short human-readable name for the variable. Distinct from
+       ``description`` (prose) and ``name`` (machine identifier).
+   * - ``multivalued``
+     - Boolean. Whether each cell of this column contains a list of
+       values rather than a single value (e.g., multi-select responses).
+   * - ``required``
+     - Boolean. Whether this column requires a value in every row.
+       Rarely accurately known at authoring time; if absent, schema
+       inference fills the gap.
+   * - ``pattern``
+     - Regular expression that all values of this column must match.
+       Power-user field; pattern inference may fill the gap if absent.
+   * - ``uri``
+     - URI or CURIE that semantically anchors this variable in a
+       controlled vocabulary (e.g., ``OMOP:1234567``). Equivalent to
+       LinkML's ``slot_uri`` for the emitted slot.
+   * - ``see_also``
+     - External references — codebooks, study protocols, standards.
+
+Type vocabulary
+---------------
+
+The canonical type vocabulary is fixed at ten values. Anything outside this
+set is disallowed.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Value
+     - Meaning
+   * - ``string``
+     - Sequence of characters.
+   * - ``integer``
+     - Whole number.
+   * - ``decimal``
+     - Real number. Covers ``float`` and ``double`` at the LinkML
+       emission layer; Schema Automator chooses the appropriate LinkML
+       primitive based on observed data.
+   * - ``boolean``
+     - True/false value.
+   * - ``date``
+     - Calendar date, ISO 8601 (``YYYY-MM-DD``) by default.
+   * - ``datetime``
+     - Date and time, ISO 8601 by default.
+   * - ``time``
+     - Time of day, ISO 8601 by default.
+   * - ``uri``
+     - Uniform Resource Identifier (full IRI form).
+   * - ``curie``
+     - Compact URI (e.g., ``OMOP:1234567``).
+   * - ``permissible_values``
+     - The variable is enumerated. The ``codes`` field declares its
+       permissible values.
+
+The vocabulary is the researcher-comprehensible subset of LinkML's built-in
+types. Technical LinkML primitives (``ncname``, ``nodeidentifier``,
+``jsonpath``, etc.) are excluded — researchers won't write them, and
+emission can't honor the distinction usefully without other context.
+
+Composite or multi-typed declarations (e.g., ``decimal, encoded``) are not
+permitted. Enumerated columns use the ``permissible_values`` type and
+declare their codes in the ``codes`` field; an integer column whose values
+are codes (e.g., ``1=Yes, 0=No``) is declared as ``permissible_values``
+with codes, not as ``integer`` with codes.
+
+Codes encoding
+--------------
+
+The ``codes`` field for ``permissible_values`` columns is a single string
+containing pipe-separated tokens. Each token is either:
+
+- ``code, label`` — a comma-separated pair, where ``code`` is the literal
+  value as it appears in the data and ``label`` is the human-readable
+  meaning. Whitespace around the separators is ignored.
+- ``value`` — bareword shorthand, interpreted as ``value, value``. Use
+  this when the literal data value is itself the human-readable form
+  (e.g., color names, country codes, status strings).
+
+Example::
+
+    1, Yes | 0, No | 2, Unknown
+    EHR | Survey | Lab
+    F, Female | M, Male | O, Other | U, Unknown
+
+Limitations: code or label values cannot contain ``|``; values containing
+``,`` must use bareword shorthand or wait for a future spec revision that
+introduces escaping.
+
+Conformance
+-----------
+
+The format defines two conformance modes:
+
+**Default mode (warn-only).** All best-practice and conditional
+requirements are reported as warnings. Tooling continues processing; the
+author sees a list of issues to address.
+
+**Strict mode (fail).** Any missing best-practice/conditional field, any
+invalid type vocabulary value, or any malformed codes encoding causes
+validation to fail. Use this in CI or when consuming a data dictionary
+that must be clean.
+
+Both modes are implemented by the same validator running against the same
+LinkML schema. Strict mode runs ``linkml-validate`` directly; default mode
+wraps it and downgrades non-fatal issues to warnings.
+
+Description content rules
+-------------------------
+
+The ``description`` field must contain only prose. The following content
+is disallowed:
+
+- Code lists or enumerated values (use ``codes``)
+- Unit declarations (use ``unit``)
+- Numeric ranges (use ``min`` and ``max``)
+- Example values (use the optional Spec B field, when added)
+
+Descriptions polluted with such content are less useful, not more, and
+indicate the author put information in the wrong place. Enforcement is
+performed by a content-quality lint (separate from structural validation)
+that flags suspicious description content.
+
+Document-level metadata
+-----------------------
+
+The format intentionally has no document-level metadata in v1. There is no
+header section, no sidecar metadata file, and no filename convention.
+Every productive option (header that breaks CSV/TSV format, sidecar that
+adds coupling, filename encoding that's fragile to parse) has worse
+trade-offs than dropping document-level metadata entirely. If a future
+revision adds it, the substrate decision will need to be revisited.
+
+Future revisions
+----------------
+
+The following are explicitly deferred from v1:
+
+- Named, reusable enum definitions (e.g., declaring an enum once and
+  referencing it from multiple ``permissible_values`` columns).
+- A ``format`` field for refining types (``string`` + ``format: email``,
+  date format strings, etc.).
+- Escaping for ``|`` and ``,`` in code values.
+- Cross-column constraints (conditional requireds, dependencies).
+- Document-level metadata and file-level conventions.
+- Per-variable provenance, lineage, and versioning.
+
+Examples
+--------
+
+Worked examples are provided in ``docs/examples/``:
+
+- ``dd_example_minimal.tsv`` — Spec A only.
+- ``dd_example_with_optional.tsv`` — Spec A plus selected Spec B columns.
+- ``dd_example_minimal.yaml`` — Spec A in YAML form.

--- a/docs/data_dictionary_format.rst
+++ b/docs/data_dictionary_format.rst
@@ -130,6 +130,13 @@ imply including ``required``.
        LinkML's ``slot_uri`` for the emitted slot.
    * - ``see_also``
      - External references — codebooks, study protocols, standards.
+       Multivalued; in TSV form, multiple values are pipe-separated within
+       a single cell.
+   * - ``example_values``
+     - Sample values for this column. Useful as authoring guidance for
+       consumers and as a fallback signal for pattern inference when
+       ``pattern`` is not provided. Multivalued; in TSV form, multiple
+       values are pipe-separated within a single cell.
 
 Type vocabulary
 ---------------
@@ -186,20 +193,42 @@ containing pipe-separated tokens. Each token is either:
 
 - ``code, label`` — a comma-separated pair, where ``code`` is the literal
   value as it appears in the data and ``label`` is the human-readable
-  meaning. Whitespace around the separators is ignored.
+  meaning. The first comma in a token separates code from label;
+  subsequent commas in the label are literal text. Whitespace around the
+  separators is ignored.
 - ``value`` — bareword shorthand, interpreted as ``value, value``. Use
   this when the literal data value is itself the human-readable form
   (e.g., color names, country codes, status strings).
 
-Example::
+Examples::
 
     1, Yes | 0, No | 2, Unknown
     EHR | Survey | Lab
     F, Female | M, Male | O, Other | U, Unknown
 
-Limitations: code or label values cannot contain ``|``; values containing
-``,`` must use bareword shorthand or wait for a future spec revision that
-introduces escaping.
+Escaping
+~~~~~~~~
+
+To include a literal ``,``, ``|``, or ``\`` in a code, prefix it with a
+backslash:
+
+- ``\,`` — literal comma
+- ``\|`` — literal pipe
+- ``\\`` — literal backslash
+
+Examples with escaping::
+
+    1, Black\, non-Hispanic | 2, White\, non-Hispanic | 3, Hispanic
+    >=$50\,000, Middle income | <$50\,000, Low income
+
+Note that labels (the part after the first comma in a ``code, label``
+token) may contain unescaped commas — only the first comma per token is
+parsed as the code/label separator. Codes (the part before the comma, or
+the entire bareword) must escape commas because the first unescaped comma
+would otherwise be parsed as the separator.
+
+Other backslash sequences (e.g., ``\n``, ``\t``) are reserved for future
+revisions and are currently invalid.
 
 Conformance
 -----------
@@ -211,13 +240,24 @@ requirements are reported as warnings. Tooling continues processing; the
 author sees a list of issues to address.
 
 **Strict mode (fail).** Any missing best-practice/conditional field, any
-invalid type vocabulary value, or any malformed codes encoding causes
-validation to fail. Use this in CI or when consuming a data dictionary
-that must be clean.
+invalid type vocabulary value, malformed codes encoding, or
+type-inappropriate field (e.g., ``codes`` on a ``boolean`` row, ``unit``
+on a ``string`` row) causes validation to fail. Use this in CI or when
+consuming a data dictionary that must be clean.
 
 Both modes are implemented by the same validator running against the same
 LinkML schema. Strict mode runs ``linkml-validate`` directly; default mode
 wraps it and downgrades non-fatal issues to warnings.
+
+A small number of content-quality concerns cannot be expressed in the
+LinkML schema cleanly and are enforced by an additional lint pass:
+
+- Descriptions containing code lists, units, ranges, or example values
+  (see "Description content rules" below).
+- Numeric ``min``/``max`` values whose numeric form does not match the
+  declared type — e.g., a fractional ``0.5`` minimum on an ``integer``
+  column. The schema accepts any number for ``min``/``max``; the lint
+  pass catches the type mismatch.
 
 Description content rules
 -------------------------
@@ -228,7 +268,7 @@ is disallowed:
 - Code lists or enumerated values (use ``codes``)
 - Unit declarations (use ``unit``)
 - Numeric ranges (use ``min`` and ``max``)
-- Example values (use the optional Spec B field, when added)
+- Example values (use ``example_values``, optional Spec B)
 
 Descriptions polluted with such content are less useful, not more, and
 indicate the author put information in the wrong place. Enforcement is

--- a/docs/examples/dd_example_minimal.tsv
+++ b/docs/examples/dd_example_minimal.tsv
@@ -1,14 +1,14 @@
 name	type	description	codes	unit	min	max
-subject_id	string	De-identified study participant identifier.
+subject_id	string	De-identified study participant identifier.				
 age_years	integer	Participant age at enrollment.		years	0	120
 weight_kg	decimal	Participant body weight at enrollment.		kg	0	500
 lab_creatinine	decimal	Serum creatinine measurement.		mg/dL	none	none
-is_smoker	boolean	Whether the participant currently smokes.
-enrollment_date	date	Date the participant was enrolled in the study.
-last_contact_datetime	datetime	Timestamp of the most recent participant contact.
-visit_time	time	Time of day the participant arrived for the visit.
-sex	permissible_values	Self-reported sex of the participant.	F, Female | M, Male | O, Other | U, Unknown
-data_source	permissible_values	Source from which this record was derived.	EHR | Survey | Lab
-race_ethnicity	permissible_values	Combined race and ethnicity classification.	1, Black\, non-Hispanic | 2, White\, non-Hispanic | 3, Hispanic
-concept_iri	uri	Reference to a controlled-vocabulary concept describing the participant's primary diagnosis.
-omop_concept_id	curie	OMOP concept identifier for the primary diagnosis.
+is_smoker	boolean	Whether the participant currently smokes.				
+enrollment_date	date	Date the participant was enrolled in the study.				
+last_contact_datetime	datetime	Timestamp of the most recent participant contact.				
+visit_time	time	Time of day the participant arrived for the visit.				
+sex	permissible_values	Self-reported sex of the participant.	F, Female | M, Male | O, Other | U, Unknown			
+data_source	permissible_values	Source from which this record was derived.	EHR | Survey | Lab			
+race_ethnicity	permissible_values	Combined race and ethnicity classification.	1, Black\, non-Hispanic | 2, White\, non-Hispanic | 3, Hispanic			
+concept_iri	uri	Reference to a controlled-vocabulary concept describing the participant's primary diagnosis.				
+omop_concept_id	curie	OMOP concept identifier for the primary diagnosis.				

--- a/docs/examples/dd_example_minimal.tsv
+++ b/docs/examples/dd_example_minimal.tsv
@@ -1,0 +1,11 @@
+name	type	description	codes	unit	min	max
+subject_id	string	De-identified study participant identifier.
+age_years	integer	Participant age at enrollment.		years	0	120
+weight_kg	decimal	Participant body weight at enrollment.		kg	0	500
+lab_creatinine	decimal	Serum creatinine measurement.		mg/dL	none	none
+is_smoker	boolean	Whether the participant currently smokes.
+enrollment_date	date	Date the participant was enrolled in the study.
+sex	permissible_values	Self-reported sex of the participant.	F, Female | M, Male | O, Other | U, Unknown
+data_source	permissible_values	Source from which this record was derived.	EHR | Survey | Lab
+concept_iri	uri	Reference to a controlled-vocabulary concept describing the participant's primary diagnosis.
+omop_concept_id	curie	OMOP concept identifier for the primary diagnosis.

--- a/docs/examples/dd_example_minimal.tsv
+++ b/docs/examples/dd_example_minimal.tsv
@@ -5,7 +5,10 @@ weight_kg	decimal	Participant body weight at enrollment.		kg	0	500
 lab_creatinine	decimal	Serum creatinine measurement.		mg/dL	none	none
 is_smoker	boolean	Whether the participant currently smokes.
 enrollment_date	date	Date the participant was enrolled in the study.
+last_contact_datetime	datetime	Timestamp of the most recent participant contact.
+visit_time	time	Time of day the participant arrived for the visit.
 sex	permissible_values	Self-reported sex of the participant.	F, Female | M, Male | O, Other | U, Unknown
 data_source	permissible_values	Source from which this record was derived.	EHR | Survey | Lab
+race_ethnicity	permissible_values	Combined race and ethnicity classification.	1, Black\, non-Hispanic | 2, White\, non-Hispanic | 3, Hispanic
 concept_iri	uri	Reference to a controlled-vocabulary concept describing the participant's primary diagnosis.
 omop_concept_id	curie	OMOP concept identifier for the primary diagnosis.

--- a/docs/examples/dd_example_minimal.yaml
+++ b/docs/examples/dd_example_minimal.yaml
@@ -33,6 +33,14 @@ entries:
     type: date
     description: Date the participant was enrolled in the study.
 
+  - name: last_contact_datetime
+    type: datetime
+    description: Timestamp of the most recent participant contact.
+
+  - name: visit_time
+    type: time
+    description: Time of day the participant arrived for the visit.
+
   - name: sex
     type: permissible_values
     description: Self-reported sex of the participant.
@@ -42,6 +50,11 @@ entries:
     type: permissible_values
     description: Source from which this record was derived.
     codes: EHR | Survey | Lab
+
+  - name: race_ethnicity
+    type: permissible_values
+    description: Combined race and ethnicity classification.
+    codes: 1, Black\, non-Hispanic | 2, White\, non-Hispanic | 3, Hispanic
 
   - name: concept_iri
     type: uri

--- a/docs/examples/dd_example_minimal.yaml
+++ b/docs/examples/dd_example_minimal.yaml
@@ -1,0 +1,54 @@
+entries:
+
+  - name: subject_id
+    type: string
+    description: De-identified study participant identifier.
+
+  - name: age_years
+    type: integer
+    description: Participant age at enrollment.
+    unit: years
+    min: 0
+    max: 120
+
+  - name: weight_kg
+    type: decimal
+    description: Participant body weight at enrollment.
+    unit: kg
+    min: 0
+    max: 500
+
+  - name: lab_creatinine
+    type: decimal
+    description: Serum creatinine measurement.
+    unit: mg/dL
+    min: none
+    max: none
+
+  - name: is_smoker
+    type: boolean
+    description: Whether the participant currently smokes.
+
+  - name: enrollment_date
+    type: date
+    description: Date the participant was enrolled in the study.
+
+  - name: sex
+    type: permissible_values
+    description: Self-reported sex of the participant.
+    codes: F, Female | M, Male | O, Other | U, Unknown
+
+  - name: data_source
+    type: permissible_values
+    description: Source from which this record was derived.
+    codes: EHR | Survey | Lab
+
+  - name: concept_iri
+    type: uri
+    description: >-
+      Reference to a controlled-vocabulary concept describing the
+      participant's primary diagnosis.
+
+  - name: omop_concept_id
+    type: curie
+    description: OMOP concept identifier for the primary diagnosis.

--- a/docs/examples/dd_example_with_optional.tsv
+++ b/docs/examples/dd_example_with_optional.tsv
@@ -1,0 +1,12 @@
+name	type	description	codes	unit	min	max	label	multivalued	uri
+subject_id	string	De-identified study participant identifier.							Subject ID
+age_years	integer	Participant age at enrollment.		years	0	120	Age (years)
+weight_kg	decimal	Participant body weight at enrollment.		kg	0	500	Weight
+lab_creatinine	decimal	Serum creatinine measurement.		mg/dL	none	none	Creatinine		LOINC:2160-0
+is_smoker	boolean	Whether the participant currently smokes.							Current smoker
+enrollment_date	date	Date the participant was enrolled in the study.							Enrollment date
+sex	permissible_values	Self-reported sex of the participant.	F, Female | M, Male | O, Other | U, Unknown				Sex
+data_source	permissible_values	Source from which this record was derived.	EHR | Survey | Lab				Data source
+medications	string	List of medications the participant is taking at enrollment.							Current medications	true
+concept_iri	uri	Reference to a controlled-vocabulary concept describing the participant's primary diagnosis.							Diagnosis concept IRI
+omop_concept_id	curie	OMOP concept identifier for the primary diagnosis.							OMOP concept

--- a/docs/examples/dd_example_with_optional.tsv
+++ b/docs/examples/dd_example_with_optional.tsv
@@ -1,15 +1,15 @@
 name	type	description	codes	unit	min	max	label	multivalued	uri	example_values
-subject_id	string	De-identified study participant identifier.							Subject ID			SUBJ001 | SUBJ002
-age_years	integer	Participant age at enrollment.		years	0	120	Age (years)
-weight_kg	decimal	Participant body weight at enrollment.		kg	0	500	Weight
+subject_id	string	De-identified study participant identifier.					Subject ID			SUBJ001 | SUBJ002
+age_years	integer	Participant age at enrollment.		years	0	120	Age (years)			
+weight_kg	decimal	Participant body weight at enrollment.		kg	0	500	Weight			
 lab_creatinine	decimal	Serum creatinine measurement.		mg/dL	none	none	Creatinine		LOINC:2160-0	0.6 | 1.0 | 1.4
-is_smoker	boolean	Whether the participant currently smokes.							Current smoker
-enrollment_date	date	Date the participant was enrolled in the study.							Enrollment date
-last_contact_datetime	datetime	Timestamp of the most recent participant contact.							Last contact
-visit_time	time	Time of day the participant arrived for the visit.							Visit time
-sex	permissible_values	Self-reported sex of the participant.	F, Female | M, Male | O, Other | U, Unknown				Sex
-data_source	permissible_values	Source from which this record was derived.	EHR | Survey | Lab				Data source
-race_ethnicity	permissible_values	Combined race and ethnicity classification.	1, Black\, non-Hispanic | 2, White\, non-Hispanic | 3, Hispanic				Race/ethnicity
-medications	string	List of medications the participant is taking at enrollment.							Current medications	true
-concept_iri	uri	Reference to a controlled-vocabulary concept describing the participant's primary diagnosis.							Diagnosis concept IRI
-omop_concept_id	curie	OMOP concept identifier for the primary diagnosis.							OMOP concept
+is_smoker	boolean	Whether the participant currently smokes.					Current smoker			
+enrollment_date	date	Date the participant was enrolled in the study.					Enrollment date			
+last_contact_datetime	datetime	Timestamp of the most recent participant contact.					Last contact			
+visit_time	time	Time of day the participant arrived for the visit.					Visit time			
+sex	permissible_values	Self-reported sex of the participant.	F, Female | M, Male | O, Other | U, Unknown				Sex			
+data_source	permissible_values	Source from which this record was derived.	EHR | Survey | Lab				Data source			
+race_ethnicity	permissible_values	Combined race and ethnicity classification.	1, Black\, non-Hispanic | 2, White\, non-Hispanic | 3, Hispanic				Race/ethnicity			
+medications	string	List of medications the participant is taking at enrollment.					Current medications	true		
+concept_iri	uri	Reference to a controlled-vocabulary concept describing the participant's primary diagnosis.					Diagnosis concept IRI			
+omop_concept_id	curie	OMOP concept identifier for the primary diagnosis.					OMOP concept			

--- a/docs/examples/dd_example_with_optional.tsv
+++ b/docs/examples/dd_example_with_optional.tsv
@@ -1,12 +1,15 @@
-name	type	description	codes	unit	min	max	label	multivalued	uri
-subject_id	string	De-identified study participant identifier.							Subject ID
+name	type	description	codes	unit	min	max	label	multivalued	uri	example_values
+subject_id	string	De-identified study participant identifier.							Subject ID			SUBJ001 | SUBJ002
 age_years	integer	Participant age at enrollment.		years	0	120	Age (years)
 weight_kg	decimal	Participant body weight at enrollment.		kg	0	500	Weight
-lab_creatinine	decimal	Serum creatinine measurement.		mg/dL	none	none	Creatinine		LOINC:2160-0
+lab_creatinine	decimal	Serum creatinine measurement.		mg/dL	none	none	Creatinine		LOINC:2160-0	0.6 | 1.0 | 1.4
 is_smoker	boolean	Whether the participant currently smokes.							Current smoker
 enrollment_date	date	Date the participant was enrolled in the study.							Enrollment date
+last_contact_datetime	datetime	Timestamp of the most recent participant contact.							Last contact
+visit_time	time	Time of day the participant arrived for the visit.							Visit time
 sex	permissible_values	Self-reported sex of the participant.	F, Female | M, Male | O, Other | U, Unknown				Sex
 data_source	permissible_values	Source from which this record was derived.	EHR | Survey | Lab				Data source
+race_ethnicity	permissible_values	Combined race and ethnicity classification.	1, Black\, non-Hispanic | 2, White\, non-Hispanic | 3, Hispanic				Race/ethnicity
 medications	string	List of medications the participant is taking at enrollment.							Current medications	true
 concept_iri	uri	Reference to a controlled-vocabulary concept describing the participant's primary diagnosis.							Diagnosis concept IRI
 omop_concept_id	curie	OMOP concept identifier for the primary diagnosis.							OMOP concept

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ schema frameworks, including:
    introduction
    install
    cli
+   data_dictionary_format
    packages/index
    metamodels/index
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ packages = ["schema_automator"]
 skip = '.git,*.lock,resources'
 check-hidden = true
 ignore-regex = '\bOGER\b'
-ignore-words-list = 'sie,assertIn'
+ignore-words-list = 'sie,assertIn,ehr'
 
 [tool.deptry.per_rule_ignores]
 DEP002 = ["psycopg2-binary", "duckdb", "mariadb", "Sphinx", "sphinx-pdj-theme", "sphinx-click", "sphinxcontrib-mermaid", "myst-parser", "setuptools"]

--- a/schema_automator/metamodels/data_dictionary.yaml
+++ b/schema_automator/metamodels/data_dictionary.yaml
@@ -1,0 +1,237 @@
+id: https://w3id.org/linkml/schema-automator/data-dictionary
+name: data_dictionary
+title: Schema Automator Data Dictionary Format
+description: >-
+  Canonical, opinionated data dictionary format consumed by Schema Automator
+  to produce maximally-enriched LinkML schemas. Designed as a forward-looking
+  target spec for new studies onboarding to data-sharing pipelines, not as a
+  format for legacy or messy data dictionaries (those are normalized to this
+  format separately). The format is row-per-variable, substrate-agnostic
+  (TSV/CSV primary, YAML sanctioned), and intentionally minimal.
+
+license: https://creativecommons.org/publicdomain/zero/1.0/
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  dd: https://w3id.org/linkml/schema-automator/data-dictionary/
+  schema: http://schema.org/
+
+default_prefix: dd
+
+imports:
+  - linkml:types
+
+classes:
+
+  DataDictionary:
+    description: >-
+      A collection of variable declarations describing the columns of a
+      tabular dataset.
+    tree_root: true
+    attributes:
+      entries:
+        description: The variable declarations in this data dictionary.
+        range: DataDictionaryEntry
+        multivalued: true
+        inlined_as_list: true
+        required: true
+
+  DataDictionaryEntry:
+    description: >-
+      A declaration of a single variable (column) in the dataset. Spec A
+      fields (name, type, description, and the type-conditional codes / unit /
+      min / max) are recommended best practice for every entry. Spec B fields
+      (label, multivalued, required, pattern, uri, see_also) are optional and
+      may be adopted independently.
+    attributes:
+
+      # ---- Spec A: recommended ----
+
+      name:
+        description: >-
+          The column name as it appears in the data file. Accepts a string
+          identifier or a URI/CURIE; URI/CURIE forms are preferred when the
+          column has a known semantic identity in a controlled vocabulary.
+        required: true
+        identifier: true
+        range: string
+
+      type:
+        description: >-
+          The data type of the variable, drawn from the canonical type
+          vocabulary. Composite or multi-typed declarations are not permitted;
+          enumerated columns use the `permissible_values` type and declare
+          their codes in the `codes` field.
+        required: true
+        range: DataDictionaryType
+
+      description:
+        description: >-
+          Human-readable prose description of what the variable represents.
+          MUST NOT contain code lists, enumerated values, unit declarations,
+          numeric ranges, or example values — those have their own fields.
+          Descriptions polluted with such content are less useful, not more,
+          and indicate the author put information in the wrong place.
+        required: true
+        range: string
+
+      codes:
+        description: >-
+          Permissible values for this variable when its type is
+          `permissible_values`. Encoded as `code, label | code, label | ...`.
+          Bareword shorthand is allowed: a token without a comma is
+          interpreted as `value, value` (the literal value serves as both the
+          code and its meaning). Code values cannot contain `|`; comma-bearing
+          values must use bareword shorthand or wait for v2 escaping.
+        range: string
+        pattern: "^[^|]+(\\|[^|]+)*$"
+
+      unit:
+        description: >-
+          The unit of measure for numeric variables. Use the literal token
+          `none` for genuinely unitless quantities (counts, ratios). An empty
+          cell means the author has not declared a unit and is reported as a
+          conformance issue; `none` is the explicit declaration of no unit.
+          UCUM-compliant units are encouraged but not required; reasonable
+          freeform units (e.g., `mg/dL`, `mmHg`, `servings/week`) are
+          accepted.
+        range: string
+
+      # min/max accept either a numeric value or the literal string "none";
+      # no top-level `range:` is set so the JSON Schema generator emits the
+      # any_of cleanly without a conflicting top-level `type: string`.
+      # The `no_undeclared_ranges` linkml-lint rule will flag these slots —
+      # the any_of expression is the range declaration, but the lint rule
+      # doesn't currently recognize that. See linkml/linkml upstream issues
+      # tracking both quirks.
+      min:
+        description: >-
+          Minimum permissible value for numeric variables. Use the literal
+          token `none` for genuinely unbounded variables. An empty cell means
+          the author has not declared a minimum and is reported as a
+          conformance issue.
+        any_of:
+          - range: decimal
+          - range: string
+            equals_string: none
+
+      max:
+        description: >-
+          Maximum permissible value for numeric variables. Use the literal
+          token `none` for genuinely unbounded variables. An empty cell means
+          the author has not declared a maximum and is reported as a
+          conformance issue.
+        any_of:
+          - range: decimal
+          - range: string
+            equals_string: none
+
+      # ---- Spec B: optional, independently adoptable ----
+
+      label:
+        description: >-
+          Short human-readable name for the variable. Distinct from
+          `description` (which is prose) and from `name` (which is the
+          machine-readable column identifier).
+        range: string
+
+      multivalued:
+        description: >-
+          Whether each cell of this column contains a list of values rather
+          than a single value (e.g., multi-select responses).
+        range: boolean
+
+      required:
+        description: >-
+          Whether this column requires a value in every row (no nulls
+          permitted). Authors are not asked to fill this in by default —
+          missing required-ness is inferred from data.
+        range: boolean
+
+      pattern:
+        description: >-
+          Regular expression that all values of this column must match.
+          Power-user field; if not provided, schema-automator may infer
+          patterns from data.
+        range: string
+
+      uri:
+        description: >-
+          URI or CURIE that semantically anchors this variable in a
+          controlled vocabulary (e.g., an OMOP concept, an OBA term).
+          Equivalent to LinkML's `slot_uri` for the emitted slot.
+        range: uriorcurie
+
+      see_also:
+        description: >-
+          External references (URIs/CURIEs) related to this variable —
+          codebooks, study protocols, standards documents.
+        range: uriorcurie
+        multivalued: true
+
+    rules:
+
+      - description: >-
+          When type is `permissible_values`, the `codes` field is required.
+        preconditions:
+          slot_conditions:
+            type:
+              equals_string: permissible_values
+        postconditions:
+          slot_conditions:
+            codes:
+              required: true
+
+      - description: >-
+          When type is numeric (integer or decimal), `unit`, `min`, and `max`
+          are required (use the literal `none` for genuinely unitless or
+          unbounded cases).
+        preconditions:
+          slot_conditions:
+            type:
+              any_of:
+                - equals_string: integer
+                - equals_string: decimal
+        postconditions:
+          slot_conditions:
+            unit:
+              required: true
+            min:
+              required: true
+            max:
+              required: true
+
+enums:
+
+  DataDictionaryType:
+    description: >-
+      The canonical data type vocabulary. Anything outside this set is
+      disallowed (warn-by-default; fail in strict mode). Curated to be
+      researcher-comprehensible: technical LinkML built-ins (ncname,
+      jsonpath, nodeidentifier, etc.) are excluded.
+    permissible_values:
+      string:
+        description: A sequence of characters.
+      integer:
+        description: A whole number.
+      decimal:
+        description: >-
+          A real number. Covers float and double at the LinkML emission
+          layer; schema-automator chooses the appropriate LinkML primitive
+          based on observed data.
+      boolean:
+        description: A true/false value.
+      date:
+        description: A calendar date, ISO 8601 (YYYY-MM-DD) by default.
+      datetime:
+        description: A date and time, ISO 8601 by default.
+      time:
+        description: A time of day, ISO 8601 by default.
+      uri:
+        description: A Uniform Resource Identifier (full IRI form).
+      curie:
+        description: A compact URI (e.g., `OMOP:1234567`).
+      permissible_values:
+        description: >-
+          The variable is enumerated. The `codes` field declares the
+          permissible values for this entry.

--- a/schema_automator/metamodels/data_dictionary.yaml
+++ b/schema_automator/metamodels/data_dictionary.yaml
@@ -69,9 +69,10 @@ classes:
         description: >-
           Human-readable prose description of what the variable represents.
           MUST NOT contain code lists, enumerated values, unit declarations,
-          numeric ranges, or example values — those have their own fields.
-          Descriptions polluted with such content are less useful, not more,
-          and indicate the author put information in the wrong place.
+          numeric ranges, or example values — those have dedicated fields
+          (`codes`, `unit`, `min`, `max`, `example_values`). Descriptions
+          polluted with such content are less useful, not more, and indicate
+          the author put information in the wrong place.
         required: true
         range: string
 
@@ -81,10 +82,14 @@ classes:
           `permissible_values`. Encoded as `code, label | code, label | ...`.
           Bareword shorthand is allowed: a token without a comma is
           interpreted as `value, value` (the literal value serves as both the
-          code and its meaning). Code values cannot contain `|`; comma-bearing
-          values must use bareword shorthand or wait for v2 escaping.
+          code and its meaning). The first comma in a token separates code
+          from label; subsequent commas in the label are literal text.
+          Special characters (`,`, `|`, `\`) are escaped with a backslash:
+          `\,` for a literal comma, `\|` for a literal pipe, `\\` for a
+          literal backslash. Other backslash sequences are reserved for
+          future revisions.
         range: string
-        pattern: "^[^|]+(\\|[^|]+)*$"
+        pattern: '^(?:[^,|\\\s]|\\[,|\\])(?:[^,|\\]|\\[,|\\])*(?:,(?:[^|\\]|\\[,|\\])+)?(?:\s*\|\s*(?:[^,|\\\s]|\\[,|\\])(?:[^,|\\]|\\[,|\\])*(?:,(?:[^|\\]|\\[,|\\])+)?)*$'
 
       unit:
         description: >-
@@ -165,8 +170,18 @@ classes:
       see_also:
         description: >-
           External references (URIs/CURIEs) related to this variable —
-          codebooks, study protocols, standards documents.
+          codebooks, study protocols, standards documents. In TSV form,
+          multiple values are encoded pipe-separated within a single cell.
         range: uriorcurie
+        multivalued: true
+
+      example_values:
+        description: >-
+          Sample values for this column. Useful as authoring guidance for
+          consumers and as a fallback signal for pattern inference when
+          `pattern` is not provided. In TSV form, multiple values are
+          encoded pipe-separated within a single cell.
+        range: string
         multivalued: true
 
     rules:
@@ -200,6 +215,61 @@ classes:
               required: true
             max:
               required: true
+
+      - description: >-
+          The `codes` field is permitted only when type is
+          `permissible_values`.
+        preconditions:
+          slot_conditions:
+            type:
+              none_of:
+                - equals_string: permissible_values
+        postconditions:
+          slot_conditions:
+            codes:
+              value_presence: ABSENT
+
+      - description: >-
+          The `unit` field is permitted only on numeric types (`integer` or
+          `decimal`).
+        preconditions:
+          slot_conditions:
+            type:
+              none_of:
+                - equals_string: integer
+                - equals_string: decimal
+        postconditions:
+          slot_conditions:
+            unit:
+              value_presence: ABSENT
+
+      - description: >-
+          The `min` field is permitted only on numeric types (`integer` or
+          `decimal`).
+        preconditions:
+          slot_conditions:
+            type:
+              none_of:
+                - equals_string: integer
+                - equals_string: decimal
+        postconditions:
+          slot_conditions:
+            min:
+              value_presence: ABSENT
+
+      - description: >-
+          The `max` field is permitted only on numeric types (`integer` or
+          `decimal`).
+        preconditions:
+          slot_conditions:
+            type:
+              none_of:
+                - equals_string: integer
+                - equals_string: decimal
+        postconditions:
+          slot_conditions:
+            max:
+              value_presence: ABSENT
 
 enums:
 


### PR DESCRIPTION
## Summary

Defines schema-automator's canonical, opinionated data dictionary format — the forward-looking target spec we ask new studies to produce when onboarding to the pipeline. Closes #191.

This is a **spec-only PR**: the deliverable is documentation + a LinkML schema + worked examples. Implementation of ingestion (#192), reconciliation (#193), and handling of non-canonical/legacy DDs (#200) is tracked separately and lands in subsequent PRs.

## What's in the spec

**Two-spec structure.** Spec A is the recommended field set for every entry: \`name\`, \`type\`, \`description\`, plus type-conditional \`codes\` (when permissible_values), \`unit\`, \`min\`, and \`max\` (when numeric). Spec B is a set of optional columns researchers may adopt independently à la carte: \`label\`, \`multivalued\`, \`required\`, \`pattern\`, \`uri\`, \`see_also\`.

**Type vocabulary fixed at 10 researcher-comprehensible values** (\`string\`, \`integer\`, \`decimal\`, \`boolean\`, \`date\`, \`datetime\`, \`time\`, \`uri\`, \`curie\`, \`permissible_values\`). Curated subset of LinkML's built-in types — technical primitives (\`ncname\`, \`jsonpath\`, etc.) are excluded.

**Codes encoded REDCap-style** as \`code, label | code, label | ...\` with bareword shorthand for value-equals-meaning cases. Comma separator (not \`=\`) avoids collisions with code values containing operators like \`>=\` or \`<=\`.

**\`none\` token** is the explicit "not applicable" value for unit/min/max — distinct from an empty cell, which means "the author has not declared this field" and is reported as a conformance issue.

**Negative requirements on \`description\`**: must not contain code lists, units, ranges, or example values — those have dedicated fields. Stated as a hard rule; enforcement is a separate content-quality lint.

**No document-level metadata in v1.** Every productive option (header that breaks CSV, sidecar coupling, filename encoding) has worse trade-offs than dropping it; the spec is intentionally substrate-only.

## Files

- \`schema_automator/metamodels/data_dictionary.yaml\` — the normative LinkML schema (10-value type vocabulary, conditional-required rules, slot definitions for Spec A and Spec B).
- \`docs/data_dictionary_format.rst\` — prose spec covering audience, conformance modes, codes encoding, type vocabulary, and deferred-to-future revisions.
- \`docs/examples/dd_example_minimal.tsv\` — Spec A example covering each type case.
- \`docs/examples/dd_example_with_optional.tsv\` — Spec A plus selected Spec B columns.
- \`docs/examples/dd_example_minimal.yaml\` — YAML equivalent.
- \`docs/index.rst\` — toctree entry for the new spec doc.

## Conformance modes

- **Default:** missing best-practice/conditional fields are reported as warnings; processing continues.
- **Strict:** any missing best-practice/conditional field, invalid type vocabulary value, or malformed codes encoding fails. Both modes use the same LinkML schema.

## Validation

The LinkML schema validates the example YAML cleanly via \`linkml-validate\`. Type vocabulary violations are caught (verified with a synthetic invalid-type example).

## Known LinkML quirks (worth filing upstream)

The \`min\` and \`max\` slots use slot-level \`any_of\` (decimal OR \`equals_string: none\`) without a top-level \`range:\`. This is because:

1. **\`gen-json-schema\` emits malformed JSON Schema** when a slot has both \`range:\` and \`any_of:\` — top-level \`type: string\` and \`anyOf\` conflict, with the type winning. Validation rejects bare numeric values in YAML.
2. **\`linkml-lint\`'s \`no_undeclared_ranges\` rule doesn't recognize \`any_of\`** as a range declaration, so it false-positives on these slots.

Both reproduce on linkml/linkml-runtime 1.10.0 (latest). A schema comment explains the workaround. Upstream issues to be filed after merge.

## Test plan

- [ ] Review spec prose for clarity and accuracy.
- [ ] Confirm the LinkML schema captures the conformance contract correctly.
- [ ] Sanity-check examples cover the type-case matrix (string, integer/decimal with units, decimal unbounded, boolean, date, permissible_values with full codes, permissible_values with bareword, uri, curie).
- [ ] Verify TSV examples render correctly in your TSV viewer of choice.
- [ ] Decide on filing the two upstream linkml issues (separate task).