### PR TITLE
Pin linkml-map to main and fix runtime 1.11 fallout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,8 @@ dependencies = [
     # populated_from, safe-builtin functions, dictionary_key, strict
     # expression mode, the SchemaReference shape for source/target_schema,
     # and the is_str / is_bool / is_list predicates the *reverse*
-    # Frictionless adapter trans-spec relies on. First shipped in the
-    # 0.5.3rc1 pre-release; tighten to ">= 0.5.3, < 1" when final lands.
-    "linkml-map >= 0.5.3rc1, < 1",
+    # Frictionless adapter trans-spec relies on.
+    "linkml-map >= 0.5.3, < 1",
     "click >= 8.1.7, < 9",
     "deprecated >= 1.2.15, < 2",
     "sqlalchemy >= 2.0.36, < 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,16 @@ dependencies = [
     "tomlkit >= 0.11.4",
     "inflect >= 6.0.0",
     "linkml-runtime >= 1.10.0, < 2",
-    # NB: the *reverse* Frictionless adapter trans-spec needs the
-    # is_str / is_bool / is_list type predicates, which land in
-    # linkml-map 0.5.3. Forward adapter and codes utility work on
-    # 0.5.2. Bump this and remove the xfail in
-    # tests/test_adapters/test_frictionless.py once 0.5.3 ships.
-    "linkml-map >= 0.5.2, < 1",
+    # Pinned to linkml-map main (see [tool.uv.sources]) — recent work
+    # adds dot-path populated_from, safe-builtin functions, dictionary_key,
+    # strict expression mode, and the SchemaReference shape for
+    # source/target_schema. The EML importer and the next batch of
+    # adapters need these. This pin also satisfies the is_str /
+    # is_bool / is_list predicate need that the *reverse* Frictionless
+    # adapter has — the xfail in tests/test_adapters/test_frictionless.py
+    # can come off once we're on a real release tag. Restore a version
+    # constraint and drop the source override here when 0.5.3+ releases.
+    "linkml-map",
     "click >= 8.1.7, < 9",
     "deprecated >= 1.2.15, < 2",
     "sqlalchemy >= 2.0.36, < 3",
@@ -93,6 +97,9 @@ extract-schema = "schema_automator.utils.schema_extractor:cli"
 [project.urls]
 repository = "https://github.com/linkml/schema-automator/"
 documentation = "https://linkml.io/schema-automator/"
+
+[tool.uv.sources]
+linkml-map = { git = "https://github.com/linkml/linkml-map.git", branch = "main" }
 
 [tool.uv-dynamic-versioning]
 vcs = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,16 +48,13 @@ dependencies = [
     "tomlkit >= 0.11.4",
     "inflect >= 6.0.0",
     "linkml-runtime >= 1.10.0, < 2",
-    # Pinned to linkml-map main (see [tool.uv.sources]) — recent work
-    # adds dot-path populated_from, safe-builtin functions, dictionary_key,
-    # strict expression mode, and the SchemaReference shape for
-    # source/target_schema. The EML importer and the next batch of
-    # adapters need these. This pin also satisfies the is_str /
-    # is_bool / is_list predicate need that the *reverse* Frictionless
-    # adapter has — the xfail in tests/test_adapters/test_frictionless.py
-    # can come off once we're on a real release tag. Restore a version
-    # constraint and drop the source override here when 0.5.3+ releases.
-    "linkml-map",
+    # 0.5.3 adds the features this batch of work needs: dot-path
+    # populated_from, safe-builtin functions, dictionary_key, strict
+    # expression mode, the SchemaReference shape for source/target_schema,
+    # and the is_str / is_bool / is_list predicates the *reverse*
+    # Frictionless adapter trans-spec relies on. First shipped in the
+    # 0.5.3rc1 pre-release; tighten to ">= 0.5.3, < 1" when final lands.
+    "linkml-map >= 0.5.3rc1, < 1",
     "click >= 8.1.7, < 9",
     "deprecated >= 1.2.15, < 2",
     "sqlalchemy >= 2.0.36, < 3",
@@ -97,9 +94,6 @@ extract-schema = "schema_automator.utils.schema_extractor:cli"
 [project.urls]
 repository = "https://github.com/linkml/schema-automator/"
 documentation = "https://linkml.io/schema-automator/"
-
-[tool.uv.sources]
-linkml-map = { git = "https://github.com/linkml/linkml-map.git", branch = "main" }
 
 [tool.uv-dynamic-versioning]
 vcs = "git"

--- a/schema_automator/adapters/dbgap/dbgap_to_dd.transform.yaml
+++ b/schema_automator/adapters/dbgap/dbgap_to_dd.transform.yaml
@@ -26,8 +26,10 @@ description: >-
     ``example_values`` but it would mix "examples" with "exhaustive
     observed values" and confuse the slot's purpose.
 
-source_schema: https://w3id.org/linkml/schema-automator/dbgap
-target_schema: https://w3id.org/linkml/schema-automator/data-dictionary
+source_schema:
+  name: https://w3id.org/linkml/schema-automator/dbgap
+target_schema:
+  name: https://w3id.org/linkml/schema-automator/data-dictionary
 
 class_derivations:
 

--- a/schema_automator/adapters/frictionless/dd_to_frictionless.transform.yaml
+++ b/schema_automator/adapters/frictionless/dd_to_frictionless.transform.yaml
@@ -24,8 +24,10 @@ description: >-
   constraint slot has a known semantic type, so the predicates
   double as both sentinel-filter and type-correctness check.
 
-source_schema: https://w3id.org/linkml/schema-automator/data-dictionary
-target_schema: https://specs.frictionlessdata.io/table-schema
+source_schema:
+  name: https://w3id.org/linkml/schema-automator/data-dictionary
+target_schema:
+  name: https://specs.frictionlessdata.io/table-schema
 
 class_derivations:
 

--- a/schema_automator/adapters/frictionless/dd_to_frictionless.transform.yaml
+++ b/schema_automator/adapters/frictionless/dd_to_frictionless.transform.yaml
@@ -80,7 +80,7 @@ class_derivations:
           {
             'required': case((is_bool(required), required)),
             'pattern': case((is_str(pattern), pattern)),
-            'enum': case((is_list(codes), [c.code for c in (codes if is_list(codes) else [])])),
+            'enum': case((is_list(codes), codes.code)),
             'minimum': case((is_numeric(min), str(min))),
             'maximum': case((is_numeric(max), str(max)))
           }

--- a/schema_automator/adapters/frictionless/frictionless_to_dd.transform.yaml
+++ b/schema_automator/adapters/frictionless/frictionless_to_dd.transform.yaml
@@ -13,8 +13,10 @@ description: >-
   - `unique`, `minLength`, `maxLength` constraints (no DD equivalent).
   - Foreign keys, `missingValues`, `primaryKey` (drop; out of DD scope).
 
-source_schema: https://specs.frictionlessdata.io/table-schema
-target_schema: https://w3id.org/linkml/schema-automator/data-dictionary
+source_schema:
+  name: https://specs.frictionlessdata.io/table-schema
+target_schema:
+  name: https://w3id.org/linkml/schema-automator/data-dictionary
 
 class_derivations:
 

--- a/schema_automator/adapters/redcap/dd_to_redcap.transform.yaml
+++ b/schema_automator/adapters/redcap/dd_to_redcap.transform.yaml
@@ -30,8 +30,10 @@ description: >-
   type, so the predicates double as both sentinel-filter and
   type-correctness check.
 
-source_schema: https://w3id.org/linkml/schema-automator/data-dictionary
-target_schema: https://projectredcap.org/data-dictionary
+source_schema:
+  name: https://w3id.org/linkml/schema-automator/data-dictionary
+target_schema:
+  name: https://projectredcap.org/data-dictionary
 
 class_derivations:
 

--- a/schema_automator/adapters/redcap/dd_to_redcap.transform.yaml
+++ b/schema_automator/adapters/redcap/dd_to_redcap.transform.yaml
@@ -43,6 +43,17 @@ class_derivations:
       entries:
         populated_from: entries
 
+  # Each `codes` entry maps to a structured RedcapChoice. The Python
+  # adapter serializes these to REDCap's `code, label | ...` string form
+  # after the transform runs.
+  RedcapChoice:
+    populated_from: PermissibleValueDefinition
+    slot_derivations:
+      code:
+        populated_from: code
+      label:
+        populated_from: label
+
   RedcapField:
     populated_from: DataDictionaryEntry
     slot_derivations:
@@ -99,7 +110,4 @@ class_derivations:
       # Pass the structured codes through; the Python adapter serializes
       # them to the REDCap CSV string form after the transform.
       choices:
-        expr: |
-          case(
-            (is_list(codes), [{'code': c.code, 'label': c.label} for c in (codes if is_list(codes) else [])])
-          )
+        populated_from: codes

--- a/schema_automator/adapters/redcap/redcap_to_dd.transform.yaml
+++ b/schema_automator/adapters/redcap/redcap_to_dd.transform.yaml
@@ -24,8 +24,10 @@ description: >-
   - `descriptive` field type — these rows are filtered out by the
     adapter before the trans-spec runs (they aren't variables).
 
-source_schema: https://projectredcap.org/data-dictionary
-target_schema: https://w3id.org/linkml/schema-automator/data-dictionary
+source_schema:
+  name: https://projectredcap.org/data-dictionary
+target_schema:
+  name: https://w3id.org/linkml/schema-automator/data-dictionary
 
 class_derivations:
 

--- a/schema_automator/adapters/redcap/redcap_to_dd.transform.yaml
+++ b/schema_automator/adapters/redcap/redcap_to_dd.transform.yaml
@@ -37,6 +37,15 @@ class_derivations:
       entries:
         populated_from: entries
 
+  # Each parsed RedcapChoice becomes a structured permissible value.
+  PermissibleValueDefinition:
+    populated_from: RedcapChoice
+    slot_derivations:
+      code:
+        populated_from: code
+      label:
+        populated_from: label
+
   DataDictionaryEntry:
     populated_from: RedcapField
     slot_derivations:
@@ -92,10 +101,10 @@ class_derivations:
 
       # Choices flow through as structured records: the adapter has
       # already parsed REDCap's `code, label | ...` string into a list
-      # of {code, label} dicts on the source side. The trans-spec just
-      # copies the list into the target slot when it's non-empty.
+      # of {code, label} dicts on the source side. Each one maps to a
+      # PermissibleValueDefinition via its own class derivation.
       codes:
-        expr: "[{'code': c.code, 'label': c.label} for c in choices] if choices else None"
+        populated_from: choices
 
       # Min/max only meaningful for numeric validations. REDCap stores
       # them as strings on the CSV; coerce to int / float based on the

--- a/schema_automator/importers/xsd_import_engine.py
+++ b/schema_automator/importers/xsd_import_engine.py
@@ -228,9 +228,13 @@ class XsdImportEngine(ImportEngine):
                     name=cls_name,
                     class_uri=urljoin(self.target_ns, cls_name) if self.target_ns else None
                 )
-                self.sb.add_class(cls)
                 slot.range = cls_name
                 self.visit_complex_type(child, cls)
+                # In linkml-runtime >=1.11 add_class() pydantic-validates
+                # its input, so the registered class is a copy; later
+                # mutations to the local `cls` don't reach it. Register
+                # after populating attributes.
+                self.sb.add_class(cls)
             elif child.tag == SIMPLE_TYPE:
                 # If we find a simple type, the range is a restriction of a primitive type
                 self.visit_simple_type(child, slot)

--- a/schema_automator/utils/instance_extractor.py
+++ b/schema_automator/utils/instance_extractor.py
@@ -52,7 +52,10 @@ class InstanceView:
         elif isinstance(obj, YAMLRoot):
             cn = type(obj).class_name
             for slot in sv.class_induced_slots(cn):
-                v = getattr(obj, slot.alias, None)
+                # slot.alias is None unless explicitly set in the schema;
+                # linkml-runtime <1.11 used to fall back to slot.name on
+                # access, 1.11 returns None. Mirror the old behavior.
+                v = getattr(obj, slot.alias or slot.name, None)
                 if v is not None:
                     if slot.identifier:
                         self.references.append((parent, v))
@@ -69,7 +72,7 @@ class InstanceView:
                         if slot.range in sv.all_classes():
                             if isinstance(v, str):
                                 self.references.append((parent, v))
-                        self.create_index(v, path=path+[slot.alias], parent=obj)
+                        self.create_index(v, path=path+[slot.alias or slot.name], parent=obj)
         logging.debug(f'Created index')
 
     def fetch_object(self, id_ref: ID_REF, default_val = None) -> Optional[YAMLRoot]:
@@ -133,7 +136,7 @@ class InstanceView:
         root_cls = type(self.root)
         for slot in self.schemaview.class_induced_slots(root_cls.class_name):
             if slot.required:
-                preserve_slots.append(slot.alias)
+                preserve_slots.append(slot.alias or slot.name)
         for slot in preserve_slots:
             xdict[slot] = getattr(self.root, slot)
         #print(f'VISITED={visited}')
@@ -156,7 +159,7 @@ class InstanceView:
             obj = seeds.pop()
             if isinstance(obj, YAMLRoot):
                 for slot in sv.class_induced_slots(type(obj).class_name):
-                    v = getattr(obj, slot.alias, None)
+                    v = getattr(obj, slot.alias or slot.name, None)
                     if v is not None:
                         if slot.identifier:
                             refs.append(v)

--- a/tests/test_adapters/test_frictionless.py
+++ b/tests/test_adapters/test_frictionless.py
@@ -3,27 +3,9 @@
 import json
 from pathlib import Path
 
-import pytest
-from linkml_map.utils.eval_utils import FUNCTIONS as _LINKML_MAP_FUNCTIONS
-
 from schema_automator.adapters.frictionless.adapter import (
     dd_to_frictionless,
     frictionless_to_dd,
-)
-
-
-# The reverse adapter's trans-spec uses linkml-map's is_str / is_bool /
-# is_list type predicates, which land in linkml-map 0.5.3. On 0.5.2 (the
-# current PyPI release) the reverse trans-spec raises FunctionNotDefined
-# at evaluation time. xfail the reverse-direction tests until the dep
-# constraint can be bumped to >= 0.5.3.
-_HAS_TYPE_PREDICATES = "is_str" in _LINKML_MAP_FUNCTIONS
-_REVERSE_REQUIRES_LINKML_MAP_053 = pytest.mark.xfail(
-    not _HAS_TYPE_PREDICATES,
-    reason="Reverse adapter trans-spec requires linkml-map >= 0.5.3 "
-    "(is_str / is_bool / is_list type predicates)",
-    strict=True,
-    raises=Exception,
 )
 
 
@@ -201,7 +183,6 @@ class TestFrictionlessToDD:
 # ----------------------------------------------------------------------
 
 
-@_REVERSE_REQUIRES_LINKML_MAP_053
 class TestDDToFrictionless:
     def test_minimal_field(self):
         source = {"entries": [{"name": "x", "type": "string", "description": "y"}]}

--- a/tests/test_importers/test_rdfs_importer.py
+++ b/tests/test_importers/test_rdfs_importer.py
@@ -61,7 +61,7 @@ def test_infer_prefix():
     """
     rdf = StringIO("""
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-    @prefix foo: <https://foo.com> .
+    @prefix foo: <https://foo.com/> .
 
     foo:Class a rdfs:Class ;
         rdfs:comment "A class." .
@@ -73,7 +73,7 @@ def test_infer_prefix():
     schema = engine.convert(rdf)
     # Although not explicitly provided, the importer should realise that the prefix is "foo"
     assert schema.default_prefix == "foo"
-    assert schema.id == "https://foo.com"
+    assert schema.id == "https://foo.com/"
     assert schema.name == "foo"
 
 def test_from_rdfs():

--- a/uv.lock
+++ b/uv.lock
@@ -1861,7 +1861,7 @@ wheels = [
 
 [[package]]
 name = "linkml-map"
-version = "0.5.3rc1"
+version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asteval" },
@@ -1886,9 +1886,9 @@ dependencies = [
     { name = "ucumvert", version = "0.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ucumvert", version = "0.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/f1/3de10694a1196befe2feaae8a560198533970643ccfa67af95ff9a9a933e/linkml_map-0.5.3rc1.tar.gz", hash = "sha256:58fe8f82058884c5052d1c2f68e515d4f60c08840a2719417b06a1a1844fa554", size = 551423, upload-time = "2026-06-17T14:45:22.626Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/65/92e03bbaa3f70c215b44729e1adc37795a01ace438f44a99f30af84f4e8b/linkml_map-0.5.3.tar.gz", hash = "sha256:2bdb16bc9546280cf03bbe9476ed3460795d612004b61e810d4206d7830093b4", size = 585678, upload-time = "2026-07-16T19:18:50.466Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/35/6abfb0ab688bc53ca5ca337385d0dcf426366e55da0a344c5ab24aaf35bf/linkml_map-0.5.3rc1-py3-none-any.whl", hash = "sha256:6b51fa6a7c905978fa62b783cca3760826db302d15698fda4c470499c84c5755", size = 131171, upload-time = "2026-06-17T14:45:21.328Z" },
+    { url = "https://files.pythonhosted.org/packages/11/01/1d8e9f0c1e51475275d9393154a69e86170e7d4a7ab17fa568935d1c24ed/linkml_map-0.5.3-py3-none-any.whl", hash = "sha256:937beba0e2ce54f669e873f80166dda9e198068eed2338e032d5a1309251556c", size = 151142, upload-time = "2026-07-16T19:18:48.621Z" },
 ]
 
 [[package]]
@@ -4162,7 +4162,7 @@ requires-dist = [
     { name = "inflect", specifier = ">=6.0.0" },
     { name = "jsonasobj2", specifier = ">=1.0.4,<2" },
     { name = "linkml", specifier = ">=1.10.0,<2" },
-    { name = "linkml-map", specifier = ">=0.5.3rc1,<1" },
+    { name = "linkml-map", specifier = ">=0.5.3,<1" },
     { name = "linkml-runtime", specifier = ">=1.10.0,<2" },
     { name = "llm", marker = "extra == 'llm'", specifier = ">=0.21,<1" },
     { name = "lxml", specifier = ">=5.3.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1825,7 +1825,7 @@ wheels = [
 
 [[package]]
 name = "linkml"
-version = "1.11.0"
+version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -1854,9 +1854,9 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/4a/5c8c6a962b8623e7009ce3a334f0c81dac4a63b11f003e617614dd50c336/linkml-1.11.0.tar.gz", hash = "sha256:bbe7f31dbfaac10047feb951b56520e9467a763d7ae08cf5d38783b70965ad53", size = 379569, upload-time = "2026-05-13T20:34:24.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/26/38e7340959cd4a87bfe5403cfcf5311d9fe2ff4382fa00e96008a1342760/linkml-1.11.1.tar.gz", hash = "sha256:2f6774e13628270cadaeecda3313db0437ecc15cd44ee35c6c2655dbe31c8524", size = 374853, upload-time = "2026-05-20T17:05:42.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/5d/e147d30b54b999c006dc86e8119d4c3bca2c4f4a49a8b4a50d37b26abfcd/linkml-1.11.0-py3-none-any.whl", hash = "sha256:8145e5ae2d90d304d135e26aac5ddff4d752d89a80e476f65a14588dfb43e7b2", size = 489194, upload-time = "2026-05-13T20:34:20.075Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/fb/3068f649cc436be915f51b2f5ac0656c83dc9bcc6d4f8940633e295042c0/linkml-1.11.1-py3-none-any.whl", hash = "sha256:d1bbb97a8b1ea4a99b145007875733a5e5e89b3acfe3e9d1e369fa4a582990ed", size = 483751, upload-time = "2026-05-20T17:05:38.663Z" },
 ]
 
 [[package]]
@@ -1908,7 +1908,7 @@ wheels = [
 
 [[package]]
 name = "linkml-runtime"
-version = "1.11.0"
+version = "1.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1926,9 +1926,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/c9/a31c30d5ff7979e01182a6c2d1c7d19d1bd2ae8cb10e2f0368cc274aae14/linkml_runtime-1.11.0.tar.gz", hash = "sha256:f06ed1f4fbb9192283333f23dd427e2019c04aad297234c1a48111f88a97b516", size = 556686, upload-time = "2026-05-13T20:34:26.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/7c/36332b49226f37d05d0dbfa4fb1c8017963d62ae722102c9c11c1f530696/linkml_runtime-1.11.1.tar.gz", hash = "sha256:e71300b596c4f35aeccd9dca096806678402213dbdb2c5e8e68f507e21320754", size = 556549, upload-time = "2026-05-20T17:05:43.633Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/1d/88aac7cac40721e12cdbbe0364ff80afc6f2620be96002bc50d11ee38621/linkml_runtime-1.11.0-py3-none-any.whl", hash = "sha256:5ccaee2763b92feb273f56f316d23a80b1d9231c5aba3cf6ad1eec5a0f8269b2", size = 654770, upload-time = "2026-05-13T20:34:22.475Z" },
+    { url = "https://files.pythonhosted.org/packages/63/1d/600b0dd24aa61f03d35293a2e9a4695add1e94c03d8701436fb52d5daf4f/linkml_runtime-1.11.1-py3-none-any.whl", hash = "sha256:b22c77d8fd920d0f4f43a6ece31393dc0b28bb47790f3e1c114210318c36b3da", size = 654566, upload-time = "2026-05-20T17:05:40.526Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -472,14 +472,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -1816,7 +1816,7 @@ wheels = [
 
 [[package]]
 name = "linkml"
-version = "1.10.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -1845,15 +1845,15 @@ dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/57/e480d016c94ac1dcfeccde3fd751fa1464545e3de2446c9ebf9fe66dd393/linkml-1.10.0.tar.gz", hash = "sha256:ca70bba1474bc7de37edd33005a8a556d4718190584ab2c88f7c46d090477d55", size = 334216, upload-time = "2026-02-25T17:13:32.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/4a/5c8c6a962b8623e7009ce3a334f0c81dac4a63b11f003e617614dd50c336/linkml-1.11.0.tar.gz", hash = "sha256:bbe7f31dbfaac10047feb951b56520e9467a763d7ae08cf5d38783b70965ad53", size = 379569, upload-time = "2026-05-13T20:34:24.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/54/0d01e407b3b8657cb1a58031e3f23e7039d26338173a130a3be30fdd8e0b/linkml-1.10.0-py3-none-any.whl", hash = "sha256:2d4934f000977489352307336267a8a4270de3156187c3394d542a0a4b8130e5", size = 434438, upload-time = "2026-02-25T17:13:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/14/5d/e147d30b54b999c006dc86e8119d4c3bca2c4f4a49a8b4a50d37b26abfcd/linkml-1.11.0-py3-none-any.whl", hash = "sha256:8145e5ae2d90d304d135e26aac5ddff4d752d89a80e476f65a14588dfb43e7b2", size = 489194, upload-time = "2026-05-13T20:34:20.075Z" },
 ]
 
 [[package]]
 name = "linkml-map"
-version = "0.5.2"
-source = { registry = "https://pypi.org/simple" }
+version = "0.5.2.post23.dev0+c4c3e62"
+source = { git = "https://github.com/linkml/linkml-map.git?branch=main#c4c3e629cfe9b5ae541d68861aac07e477715997" }
 dependencies = [
     { name = "asteval" },
     { name = "click" },
@@ -1875,10 +1875,6 @@ dependencies = [
     { name = "ucumvert", version = "0.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ucumvert", version = "0.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/96/b1edb3f70d76fa2b6b2570ec3c237e408cba16dec3f1195ef3dffe600c2c/linkml_map-0.5.2.tar.gz", hash = "sha256:4baf76f17eebb7e70f1d30be72f71de79cbeee537aa3c5791e7af10b575c6998", size = 434126, upload-time = "2026-04-07T14:37:05.15Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/f5/f97a5f0ba30a012120cae8bfdfa06ddfbb39a75ff4269d006453aef96bb1/linkml_map-0.5.2-py3-none-any.whl", hash = "sha256:2a2249fa3d82aa859388eb8c55ca03e9679ca0cc5e1bf7ccde8c0fb96522972a", size = 86317, upload-time = "2026-04-07T14:37:03.946Z" },
-]
 
 [[package]]
 name = "linkml-renderer"
@@ -1897,7 +1893,7 @@ wheels = [
 
 [[package]]
 name = "linkml-runtime"
-version = "1.10.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1915,9 +1911,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/3d/031e2e8ef7ca872340fb7b7102cfd1fe4a0b329dc04ff694ad9ec6ccaddc/linkml_runtime-1.10.0.tar.gz", hash = "sha256:899889d584ce8056c5c44512b2d247bdc84a8484c3aa228aeb2db283e3a9d2ec", size = 589957, upload-time = "2026-02-25T17:13:34.034Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/c9/a31c30d5ff7979e01182a6c2d1c7d19d1bd2ae8cb10e2f0368cc274aae14/linkml_runtime-1.11.0.tar.gz", hash = "sha256:f06ed1f4fbb9192283333f23dd427e2019c04aad297234c1a48111f88a97b516", size = 556686, upload-time = "2026-05-13T20:34:26.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/2d/6ab4127bb9aa6e3b54ad5d81fd0c0c12e4d1a80300f2bfdac8f2e18f9d17/linkml_runtime-1.10.0-py3-none-any.whl", hash = "sha256:b7caf806e1b49bf62005d8f398b070c282742c5f6626469fdc1660add0c9da58", size = 584001, upload-time = "2026-02-25T17:13:30.603Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1d/88aac7cac40721e12cdbbe0364ff80afc6f2620be96002bc50d11ee38621/linkml_runtime-1.11.0-py3-none-any.whl", hash = "sha256:5ccaee2763b92feb273f56f316d23a80b1d9231c5aba3cf6ad1eec5a0f8269b2", size = 654770, upload-time = "2026-05-13T20:34:22.475Z" },
 ]
 
 [[package]]
@@ -4139,7 +4135,7 @@ requires-dist = [
     { name = "inflect", specifier = ">=6.0.0" },
     { name = "jsonasobj2", specifier = ">=1.0.4,<2" },
     { name = "linkml", specifier = ">=1.10.0,<2" },
-    { name = "linkml-map", specifier = ">=0.5.2,<1" },
+    { name = "linkml-map", git = "https://github.com/linkml/linkml-map.git?branch=main" },
     { name = "linkml-runtime", specifier = ">=1.10.0,<2" },
     { name = "llm", marker = "extra == 'llm'", specifier = ">=0.21,<1" },
     { name = "lxml", specifier = ">=5.3.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1164,6 +1164,15 @@ wheels = [
 ]
 
 [[package]]
+name = "inflection"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091, upload-time = "2020-08-22T08:16:29.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454, upload-time = "2020-08-22T08:16:27.816Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1852,8 +1861,8 @@ wheels = [
 
 [[package]]
 name = "linkml-map"
-version = "0.5.2.post23.dev0+c4c3e62"
-source = { git = "https://github.com/linkml/linkml-map.git?branch=main#c4c3e629cfe9b5ae541d68861aac07e477715997" }
+version = "0.5.3rc1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asteval" },
     { name = "click" },
@@ -1862,6 +1871,7 @@ dependencies = [
     { name = "duckdb" },
     { name = "flatten-dict" },
     { name = "graphviz" },
+    { name = "inflection" },
     { name = "jinja2" },
     { name = "lark" },
     { name = "linkml" },
@@ -1870,10 +1880,15 @@ dependencies = [
     { name = "pint", version = "0.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pint", version = "0.25.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
+    { name = "python-slugify" },
     { name = "pyyaml" },
     { name = "simpleeval" },
     { name = "ucumvert", version = "0.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ucumvert", version = "0.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f1/3de10694a1196befe2feaae8a560198533970643ccfa67af95ff9a9a933e/linkml_map-0.5.3rc1.tar.gz", hash = "sha256:58fe8f82058884c5052d1c2f68e515d4f60c08840a2719417b06a1a1844fa554", size = 551423, upload-time = "2026-06-17T14:45:22.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/35/6abfb0ab688bc53ca5ca337385d0dcf426366e55da0a344c5ab24aaf35bf/linkml_map-0.5.3rc1-py3-none-any.whl", hash = "sha256:6b51fa6a7c905978fa62b783cca3760826db302d15698fda4c470499c84c5755", size = 131171, upload-time = "2026-06-17T14:45:21.328Z" },
 ]
 
 [[package]]
@@ -3577,6 +3592,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
 name = "python-ulid"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4135,7 +4162,7 @@ requires-dist = [
     { name = "inflect", specifier = ">=6.0.0" },
     { name = "jsonasobj2", specifier = ">=1.0.4,<2" },
     { name = "linkml", specifier = ">=1.10.0,<2" },
-    { name = "linkml-map", git = "https://github.com/linkml/linkml-map.git?branch=main" },
+    { name = "linkml-map", specifier = ">=0.5.3rc1,<1" },
     { name = "linkml-runtime", specifier = ">=1.10.0,<2" },
     { name = "llm", marker = "extra == 'llm'", specifier = ">=0.21,<1" },
     { name = "lxml", specifier = ">=5.3.0" },
@@ -4710,6 +4737,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Prerequisite for the EML importer (#208) and adjacent adapter work that needs unreleased linkml-map features: dot-path \`populated_from\`, safe-builtin functions, \`dictionary_key\`, strict expression mode.

Pinning surfaces fallout from the linkml-runtime 1.10 → 1.11 transition:

- \`source_schema\` / \`target_schema\` in trans-specs must be \`SchemaReference\` dicts (\`{name: <id>}\`), not bare strings — three adapter specs updated.
- \`ClassDefinition.attributes\` no longer mutates via a local alias after \`add_class\` (pydantic v2 copy semantics); XSD importer swaps the order so attributes are populated before registration.
- \`SlotDefinition.alias\` returns \`None\` when not explicitly set (used to fall back to \`slot.name\`); \`instance_extractor\` now does the fallback inline.
- 1.11 \`URIorCURIE\` validation is stricter; \`test_infer_prefix\` had used a prefix without trailing separator that expanded to a malformed URI — test data fixed.

All 160 tests pass. Revert the pin (back to a version constraint) when linkml-map 0.5.3+ releases.

## Test plan
- [x] \`pytest tests/\` green (160 passed, 3 skipped)