### PR TITLE
Update external GitHub workflows

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -27,10 +27,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -38,14 +38,14 @@ jobs:
       #              install uv
       #----------------------------------------------
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
 
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------
       - name: Load cached venv
         id: cached-uv-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/uv.lock') }}

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,6 +18,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@v2.2

--- a/.github/workflows/doc_pages.yaml
+++ b/.github/workflows/doc_pages.yaml
@@ -8,17 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
     - name: Set up Python 3.
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
 
     - name: Install dependencies
       run: uv sync --extra docs
@@ -34,7 +34,7 @@ jobs:
 
     - name: Deploy documentation.
       if: ${{ github.event_name == 'push' }}
-      uses: JamesIves/github-pages-deploy-action@v4.3.0
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         force: true

--- a/.github/workflows/doc_pages.yaml
+++ b/.github/workflows/doc_pages.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
       with:
-        fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+        fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
     - name: Set up Python 3.
       uses: actions/setup-python@v6

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,23 +10,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
 
       - name: Build source and wheel archives
         run: uv build
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Updates from `gh-external-audit update`:

- actions/cache: v4 → v5 (major tag)
- actions/checkout: v4 → v6 (major tag)
- actions/setup-python: v5 → v6 (major tag)
- astral-sh/setup-uv: v6 → fac544c0 (SHA) — setup-uv v8 stopped publishing moving major/minor tags (@v8 no longer exists); maintainer recommends githash pinning for supply-chain safety. Pinned to v8.2.0's commit.
- codespell-project/actions-codespell: v2 → v2.2 (exact tag) — the moving `v2` tag is stale (still points at a May-2024 commit, older than v2.1/v2.2); pinned to exact v2.2 to actually pick up the update.
- JamesIves/github-pages-deploy-action: v4.3.0 → v4 (major tag) — bumped exact v4.3.0 pin to the moving v4 tag; workflow's force/branch/folder inputs are unchanged in v4.8.0.
- pypa/gh-action-pypi-publish: v1.5.0 → v1.14.0 (exact tag) — no moving v1 major tag is published; token auth (user/password) is still supported in v1.14.0 (v1.7 only deprecated snake_case for multi-word inputs, removal slated for v3+). Pinned to exact v1.14.0.
