### PR TITLE
Add extract-dd: project a LinkML schema into the canonical DD format

### DIFF
--- a/schema_automator/cli.py
+++ b/schema_automator/cli.py
@@ -786,7 +786,7 @@ def extract_dd(schema_path: str, class_name: str | None, output: str, tsv: bool)
 
     With --class, projects that one class to stdout (or -o). Without it,
     projects every concrete class in batch mode, writing one
-    ``<schema-id>.<class>.dd.{yaml,tsv}`` per class into the -o directory.
+    ``<schema-name>.<class>.dd.{yaml,tsv}`` per class into the -o directory.
     """
     from linkml_runtime.utils.schemaview import SchemaView
 

--- a/schema_automator/cli.py
+++ b/schema_automator/cli.py
@@ -762,5 +762,72 @@ def adapt_dbgap(data_dict_path: str, var_report_path: str | None, output: str, t
         click.echo(out_text)
 
 
+@main.command()
+@click.argument('schema_path', metavar='SCHEMA')
+@click.option(
+    '--class',
+    'class_name',
+    default=None,
+    help='Project just this class. Omit to project all concrete classes (batch mode; requires -o to be a directory).',
+)
+@output_option
+@click.option(
+    '--tsv/--yaml',
+    default=False,
+    help='Output format. Default is YAML (lossless structured codes). --tsv emits the canonical DD TSV serialization grammar.',
+)
+def extract_dd(schema_path: str, class_name: str | None, output: str, tsv: bool):
+    """
+    Project a LinkML schema into the canonical data dictionary format.
+
+    SCHEMA is a path to a LinkML schema (including importer output:
+    XSD, JSON Schema, OWL, RDFS, SQL DDL, EML). Each class becomes a
+    data dictionary; each slot becomes an entry.
+
+    With --class, projects that one class to stdout (or -o). Without it,
+    projects every concrete class in batch mode, writing one
+    ``<schema-id>.<class>.dd.{yaml,tsv}`` per class into the -o directory.
+    """
+    from linkml_runtime.utils.schemaview import SchemaView
+
+    from schema_automator.utils.extract_dd import (
+        dd_to_tsv,
+        projectable_classes,
+        schema_to_dd,
+    )
+
+    sv = SchemaView(schema_path)
+
+    def render(dd: dict) -> str:
+        if tsv:
+            return dd_to_tsv(dd)
+        return yaml.safe_dump(dd, sort_keys=False, allow_unicode=True)
+
+    if class_name:
+        out_text = render(schema_to_dd(sv, class_name))
+        if output:
+            Path(output).parent.mkdir(parents=True, exist_ok=True)
+            with open(output, 'w') as f:
+                f.write(out_text)
+        else:
+            click.echo(out_text)
+        return
+
+    if not output:
+        raise click.ClickException(
+            "batch mode (no --class) requires -o <directory> to write one DD per class"
+        )
+    os.makedirs(output, exist_ok=True)
+    ext = 'tsv' if tsv else 'yaml'
+    schema_id = sv.schema.name or 'schema'
+    classes = projectable_classes(sv)
+    for cname in classes:
+        dd = schema_to_dd(sv, cname)
+        out_path = os.path.join(output, f"{schema_id}.{cname}.dd.{ext}")
+        with open(out_path, 'w') as f:
+            f.write(render(dd))
+    click.echo(f"Wrote {len(classes)} data dictionaries to {output}")
+
+
 if __name__ == "__main__":
     main()

--- a/schema_automator/utils/extract_dd.py
+++ b/schema_automator/utils/extract_dd.py
@@ -12,16 +12,16 @@ Each class becomes a ``DataDictionary``; each (induced) slot becomes a
 Mapping:
 
 - ``slot.range`` → DD ``type`` via :data:`_RANGE_TO_DD_TYPE`; enum ranges
-  become ``type: permissible_values`` with the enum projected into
-  ``codes``.
-- ``description``, ``title`` → ``label``, ``slot_uri`` → ``uri``,
-  ``pattern``, ``multivalued``, ``required`` (when True), ``see_also``,
-  ``examples`` → ``example_values``, ``minimum_value`` / ``maximum_value``
-  → ``min`` / ``max`` carry through.
-- ``unit`` (a UCUM-flavored object) collapses best-effort to a string.
-- Numeric entries (``integer`` / ``decimal``) get the literal ``none``
-  sentinel for any of ``unit`` / ``min`` / ``max`` not declared, so the
-  output satisfies the canonical DD's numeric-conformance rules.
+  become ``type: permissible_values`` with ``codes`` always present (an
+  empty list for a value-less enum).
+- ``description`` is always emitted (``""`` when the slot has none, since
+  the canonical DD requires it); ``title`` → ``label``, ``slot_uri`` →
+  ``uri``, ``pattern``, ``multivalued``, ``required`` (when True),
+  ``see_also``, and ``examples`` → ``example_values`` carry through.
+- ``unit`` / ``min`` / ``max`` are emitted only for numeric entries
+  (``integer`` / ``decimal``) — where the canonical DD both permits and
+  requires them — using the literal ``none`` sentinel for anything not
+  declared. ``unit`` collapses best-effort from its UCUM-flavored object.
 - Slots whose range is a class are skipped — they aren't flat columns.
 """
 
@@ -137,14 +137,15 @@ def _slot_to_entry(schemaview: SchemaView, slot) -> Optional[dict[str, Any]]:
 
     if rng and rng in schemaview.all_enums():
         entry["type"] = "permissible_values"
-        codes = _enum_codes(schemaview, rng)
-        if codes:
-            entry["codes"] = codes
+        # codes is required whenever type is permissible_values — emit
+        # the key unconditionally (empty list for a value-less enum).
+        entry["codes"] = _enum_codes(schemaview, rng)
     else:
         entry["type"] = _RANGE_TO_DD_TYPE.get(rng, "string")
 
-    if slot.description:
-        entry["description"] = slot.description
+    # description is required by the canonical DD; emit "" when the slot
+    # has none (also a clean signal for a later enrichment pass to fill).
+    entry["description"] = slot.description or ""
     if slot.title:
         entry["label"] = slot.title
     if slot.slot_uri:
@@ -166,20 +167,18 @@ def _slot_to_entry(schemaview: SchemaView, slot) -> Optional[dict[str, Any]]:
     if example_values:
         entry["example_values"] = example_values
 
-    unit = _unit_to_str(slot.unit)
-    if unit:
-        entry["unit"] = unit
-    if slot.minimum_value is not None:
-        entry["min"] = slot.minimum_value
-    if slot.maximum_value is not None:
-        entry["max"] = slot.maximum_value
-
-    # Numeric entries must declare unit/min/max per the canonical DD
-    # rules; use the explicit `none` sentinel for anything undeclared.
+    # unit/min/max are permitted only on numeric types per the canonical
+    # DD rules, and required there — carry declared values through, else
+    # the explicit `none` sentinel. Non-numeric slots never emit them.
     if entry["type"] in _NUMERIC_DD_TYPES:
-        entry.setdefault("unit", "none")
-        entry.setdefault("min", "none")
-        entry.setdefault("max", "none")
+        unit = _unit_to_str(slot.unit)
+        entry["unit"] = unit if unit else "none"
+        entry["min"] = (
+            slot.minimum_value if slot.minimum_value is not None else "none"
+        )
+        entry["max"] = (
+            slot.maximum_value if slot.maximum_value is not None else "none"
+        )
 
     return entry
 

--- a/schema_automator/utils/extract_dd.py
+++ b/schema_automator/utils/extract_dd.py
@@ -1,0 +1,215 @@
+"""Project a LinkML schema into the canonical data dictionary format.
+
+The inverse of the adapter family (foreign DD → canonical DD) and the
+enricher (canonical DD → LinkML schema): this takes any LinkML schema —
+including the output of the importers (XSD, JSON Schema, OWL, RDFS, SQL
+DDL, EML) — and projects each class into a canonical Data Dictionary
+matching ``schema_automator/metamodels/data_dictionary.yaml``.
+
+Each class becomes a ``DataDictionary``; each (induced) slot becomes a
+``DataDictionaryEntry``. See issue #209.
+
+Mapping:
+
+- ``slot.range`` → DD ``type`` via :data:`_RANGE_TO_DD_TYPE`; enum ranges
+  become ``type: permissible_values`` with the enum projected into
+  ``codes``.
+- ``description``, ``title`` → ``label``, ``slot_uri`` → ``uri``,
+  ``pattern``, ``multivalued``, ``required`` (when True), ``see_also``,
+  ``examples`` → ``example_values``, ``minimum_value`` / ``maximum_value``
+  → ``min`` / ``max`` carry through.
+- ``unit`` (a UCUM-flavored object) collapses best-effort to a string.
+- Numeric entries (``integer`` / ``decimal``) get the literal ``none``
+  sentinel for any of ``unit`` / ``min`` / ``max`` not declared, so the
+  output satisfies the canonical DD's numeric-conformance rules.
+- Slots whose range is a class are skipped — they aren't flat columns.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from linkml_runtime.utils.schemaview import SchemaView
+
+from schema_automator.adapters.codes import serialize_codes
+
+
+# LinkML built-in range → canonical DD type vocabulary. Ranges absent
+# from this map (and not an enum or class) fall back to ``string``.
+_RANGE_TO_DD_TYPE = {
+    "string": "string",
+    "integer": "integer",
+    "float": "decimal",
+    "double": "decimal",
+    "decimal": "decimal",
+    "boolean": "boolean",
+    "date": "date",
+    "datetime": "datetime",
+    "time": "time",
+    "uri": "uri",
+    "uriorcurie": "uri",
+    "curie": "curie",
+}
+
+_NUMERIC_DD_TYPES = {"integer", "decimal"}
+
+# Column order for the canonical DD TSV serialization.
+_TSV_COLUMNS = [
+    "name", "type", "description", "codes", "unit", "min", "max",
+    "label", "multivalued", "required", "pattern", "uri", "see_also",
+    "example_values",
+]
+
+
+def schema_to_dd(schemaview: SchemaView, class_name: str) -> dict[str, Any]:
+    """Project one class of a LinkML schema into a canonical DD dict.
+
+    Parameters
+    ----------
+    schemaview : SchemaView
+        A SchemaView over the source schema.
+    class_name : str
+        The class to project. Its induced slots (inherited + local)
+        become the DD entries.
+
+    Returns
+    -------
+    dict
+        ``{"entries": [...]}`` matching
+        ``schema_automator/metamodels/data_dictionary.yaml``.
+    """
+    if schemaview.get_class(class_name) is None:
+        raise ValueError(
+            f"extract_dd: class {class_name!r} not in schema "
+            f"(known: {sorted(schemaview.all_classes())})"
+        )
+    entries = []
+    for slot in schemaview.class_induced_slots(class_name):
+        entry = _slot_to_entry(schemaview, slot)
+        if entry is not None:
+            entries.append(entry)
+    return {"entries": entries}
+
+
+def projectable_classes(schemaview: SchemaView) -> list[str]:
+    """Return the names of classes worth projecting in batch mode.
+
+    Excludes mixins and abstract classes — they describe structure for
+    reuse rather than concrete datasets.
+    """
+    return [
+        name
+        for name, cls in schemaview.all_classes().items()
+        if not cls.abstract and not cls.mixin
+    ]
+
+
+def dd_to_tsv(data_dictionary: dict[str, Any]) -> str:
+    """Serialize a canonical DD dict to the canonical TSV grammar.
+
+    Multivalued cells (``see_also``, ``example_values``) are pipe-joined;
+    ``codes`` uses the ``code, label | ...`` codes grammar.
+    """
+    lines = ["\t".join(_TSV_COLUMNS)]
+    for entry in data_dictionary.get("entries", []):
+        row = []
+        for col in _TSV_COLUMNS:
+            value = entry.get(col)
+            if col == "codes" and isinstance(value, list):
+                value = serialize_codes(value)
+            elif isinstance(value, bool):
+                value = "true" if value else "false"
+            elif isinstance(value, list):
+                value = "|".join(str(v) for v in value)
+            row.append("" if value is None else str(value))
+        lines.append("\t".join(row))
+    return "\n".join(lines) + "\n"
+
+
+def _slot_to_entry(schemaview: SchemaView, slot) -> Optional[dict[str, Any]]:
+    """Project one induced slot into a DataDictionaryEntry dict, or None
+    if the slot has no flat-column representation (class-ranged)."""
+    rng = slot.range
+    if rng and rng in schemaview.all_classes():
+        return None
+
+    entry: dict[str, Any] = {"name": slot.name}
+
+    if rng and rng in schemaview.all_enums():
+        entry["type"] = "permissible_values"
+        codes = _enum_codes(schemaview, rng)
+        if codes:
+            entry["codes"] = codes
+    else:
+        entry["type"] = _RANGE_TO_DD_TYPE.get(rng, "string")
+
+    if slot.description:
+        entry["description"] = slot.description
+    if slot.title:
+        entry["label"] = slot.title
+    if slot.slot_uri:
+        entry["uri"] = slot.slot_uri
+    if slot.pattern:
+        entry["pattern"] = slot.pattern
+    if slot.multivalued:
+        entry["multivalued"] = True
+    if slot.required:
+        entry["required"] = True
+
+    see_also = list(slot.see_also or [])
+    if see_also:
+        entry["see_also"] = see_also
+
+    example_values = [
+        ex.value for ex in (slot.examples or []) if getattr(ex, "value", None)
+    ]
+    if example_values:
+        entry["example_values"] = example_values
+
+    unit = _unit_to_str(slot.unit)
+    if unit:
+        entry["unit"] = unit
+    if slot.minimum_value is not None:
+        entry["min"] = slot.minimum_value
+    if slot.maximum_value is not None:
+        entry["max"] = slot.maximum_value
+
+    # Numeric entries must declare unit/min/max per the canonical DD
+    # rules; use the explicit `none` sentinel for anything undeclared.
+    if entry["type"] in _NUMERIC_DD_TYPES:
+        entry.setdefault("unit", "none")
+        entry.setdefault("min", "none")
+        entry.setdefault("max", "none")
+
+    return entry
+
+
+def _enum_codes(schemaview: SchemaView, enum_name: str) -> list[dict[str, Any]]:
+    """Project an enum's permissible values into DD code records."""
+    enum = schemaview.get_enum(enum_name)
+    codes = []
+    for pv in (enum.permissible_values or {}).values():
+        code: dict[str, Any] = {"code": pv.text}
+        if pv.title:
+            code["label"] = pv.title
+        if pv.description:
+            code["description"] = pv.description
+        if pv.meaning:
+            code["uri"] = pv.meaning
+        codes.append(code)
+    return codes
+
+
+def _unit_to_str(unit) -> Optional[str]:
+    """Collapse LinkML's UCUM-flavored unit object to a freeform string.
+
+    Best-effort: prefer ``symbol``, then ``ucum_code``, then
+    ``descriptive_name``. Returns None when no unit is set.
+    """
+    if not unit:
+        return None
+    for attr in ("symbol", "ucum_code", "descriptive_name"):
+        value = getattr(unit, attr, None)
+        if value:
+            return value
+    return None

--- a/tests/test_utils/test_extract_dd.py
+++ b/tests/test_utils/test_extract_dd.py
@@ -105,6 +105,8 @@ def test_inherited_slot_included(person_entries):
     # record_id comes from Base via is_a; class_induced_slots picks it up.
     assert "record_id" in person_entries
     assert person_entries["record_id"]["type"] == "string"
+    # description is required by the DD; a slot without one gets "".
+    assert person_entries["record_id"]["description"] == ""
 
 
 def test_metadata_carried(person_entries):
@@ -112,6 +114,8 @@ def test_metadata_carried(person_entries):
     assert e["type"] == "string"
     assert e["description"] == "The person's full name"
     assert e["label"] == "Full Name"
+    # unit/min/max are numeric-only; a string slot must not carry them.
+    assert "unit" not in e and "min" not in e and "max" not in e
 
 
 def test_numeric_with_bounds_gets_none_unit(person_entries):
@@ -172,6 +176,31 @@ def test_projectable_classes_excludes_mixin_and_abstract(sv):
 def test_unknown_class_raises(sv):
     with pytest.raises(ValueError, match="not in schema"):
         schema_to_dd(sv, "NotAClass")
+
+
+def test_empty_enum_still_emits_codes_key(tmp_path):
+    # codes is required whenever type is permissible_values — even a
+    # value-less enum must emit the key (as an empty list).
+    schema = """
+    id: https://example.org/e
+    name: e
+    prefixes: {linkml: https://w3id.org/linkml/}
+    imports: [linkml:types]
+    classes:
+      Thing:
+        slots: [kind]
+    slots:
+      kind:
+        range: EmptyEnum
+    enums:
+      EmptyEnum: {}
+    """
+    path = tmp_path / "e.yaml"
+    path.write_text(dedent(schema).strip() + "\n")
+    sv_e = SchemaView(str(path))
+    entry = schema_to_dd(sv_e, "Thing")["entries"][0]
+    assert entry["type"] == "permissible_values"
+    assert entry["codes"] == []
 
 
 def test_dd_to_tsv_header_and_codes(sv):

--- a/tests/test_utils/test_extract_dd.py
+++ b/tests/test_utils/test_extract_dd.py
@@ -1,0 +1,186 @@
+"""Tests for projecting a LinkML schema into the canonical DD format."""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from linkml_runtime.utils.schemaview import SchemaView
+
+from schema_automator.utils.extract_dd import (
+    dd_to_tsv,
+    projectable_classes,
+    schema_to_dd,
+)
+
+
+_SCHEMA = """
+id: https://example.org/t
+name: test_schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+  ex: https://example.org/
+default_range: string
+imports: [linkml:types]
+classes:
+  Base:
+    slots: [record_id]
+  Person:
+    is_a: Base
+    slots:
+      - full_name
+      - age
+      - score
+      - status
+      - height
+      - email
+      - tags
+      - homepage
+      - address
+  Address:
+    slots: [city]
+  Mixinish:
+    mixin: true
+  AbstractThing:
+    abstract: true
+slots:
+  record_id:
+    identifier: true
+    range: string
+  full_name:
+    range: string
+    description: The person's full name
+    title: Full Name
+  age:
+    range: integer
+    minimum_value: 0
+    maximum_value: 120
+  score:
+    range: integer
+  status:
+    range: StatusEnum
+  height:
+    range: float
+    unit:
+      ucum_code: cm
+  email:
+    range: string
+    pattern: "[a-z]+"
+  tags:
+    range: string
+    multivalued: true
+  homepage:
+    range: uri
+    slot_uri: schema:url
+  address:
+    range: Address
+  city:
+    range: string
+enums:
+  StatusEnum:
+    permissible_values:
+      ACTIVE:
+        title: Active
+        description: Currently active
+        meaning: ex:Active
+      INACTIVE:
+        title: Inactive
+"""
+
+
+@pytest.fixture(scope="module")
+def sv(tmp_path_factory) -> SchemaView:
+    path = tmp_path_factory.mktemp("extract_dd") / "schema.yaml"
+    path.write_text(dedent(_SCHEMA).strip() + "\n")
+    return SchemaView(str(path))
+
+
+@pytest.fixture(scope="module")
+def person_entries(sv) -> dict:
+    dd = schema_to_dd(sv, "Person")
+    return {e["name"]: e for e in dd["entries"]}
+
+
+def test_inherited_slot_included(person_entries):
+    # record_id comes from Base via is_a; class_induced_slots picks it up.
+    assert "record_id" in person_entries
+    assert person_entries["record_id"]["type"] == "string"
+
+
+def test_metadata_carried(person_entries):
+    e = person_entries["full_name"]
+    assert e["type"] == "string"
+    assert e["description"] == "The person's full name"
+    assert e["label"] == "Full Name"
+
+
+def test_numeric_with_bounds_gets_none_unit(person_entries):
+    e = person_entries["age"]
+    assert e["type"] == "integer"
+    assert e["min"] == 0
+    assert e["max"] == 120
+    # unit undeclared on a numeric slot → explicit `none` sentinel.
+    assert e["unit"] == "none"
+
+
+def test_numeric_bare_gets_all_none_sentinels(person_entries):
+    e = person_entries["score"]
+    assert e["type"] == "integer"
+    assert e["unit"] == "none"
+    assert e["min"] == "none"
+    assert e["max"] == "none"
+
+
+def test_enum_range_projects_to_permissible_values(person_entries):
+    e = person_entries["status"]
+    assert e["type"] == "permissible_values"
+    codes = {c["code"]: c for c in e["codes"]}
+    assert set(codes) == {"ACTIVE", "INACTIVE"}
+    assert codes["ACTIVE"]["label"] == "Active"
+    assert codes["ACTIVE"]["description"] == "Currently active"
+    assert "Active" in codes["ACTIVE"]["uri"]
+
+
+def test_float_maps_to_decimal_with_unit(person_entries):
+    e = person_entries["height"]
+    assert e["type"] == "decimal"
+    assert e["unit"] == "cm"
+    # decimal is numeric → undeclared bounds become `none`.
+    assert e["min"] == "none"
+    assert e["max"] == "none"
+
+
+def test_pattern_and_multivalued_and_uri(person_entries):
+    assert person_entries["email"]["pattern"] == "[a-z]+"
+    assert person_entries["tags"]["multivalued"] is True
+    assert person_entries["homepage"]["type"] == "uri"
+    assert "url" in person_entries["homepage"]["uri"]
+
+
+def test_class_ranged_slot_skipped(person_entries):
+    # address has a class range — not a flat column.
+    assert "address" not in person_entries
+
+
+def test_projectable_classes_excludes_mixin_and_abstract(sv):
+    classes = set(projectable_classes(sv))
+    assert {"Base", "Person", "Address"} <= classes
+    assert "Mixinish" not in classes
+    assert "AbstractThing" not in classes
+
+
+def test_unknown_class_raises(sv):
+    with pytest.raises(ValueError, match="not in schema"):
+        schema_to_dd(sv, "NotAClass")
+
+
+def test_dd_to_tsv_header_and_codes(sv):
+    dd = schema_to_dd(sv, "Person")
+    tsv = dd_to_tsv(dd)
+    lines = tsv.splitlines()
+    header = lines[0].split("\t")
+    assert header[:4] == ["name", "type", "description", "codes"]
+    status_row = next(line for line in lines if line.startswith("status\t"))
+    # codes serialized via the canonical `code, label | ...` grammar.
+    assert "ACTIVE" in status_row and "Active" in status_row
+    assert "|" in status_row


### PR DESCRIPTION
Closes #209.

Adds `schemauto extract-dd <schema> [--class X] [-o] [--tsv/--yaml]` and `schema_automator/utils/extract_dd.py` (`schema_to_dd`, `projectable_classes`, `dd_to_tsv`). Projects each class of a LinkML schema into a canonical data dictionary: slots → entries, ranges → DD types, enum ranges → `permissible_values` + `codes`, `unit`/`min`/`max`/`pattern`/`slot_uri`/etc. carried through. Inherited slots included via `class_induced_slots`; class-ranged slots skipped; numeric entries emit the `none` sentinel for undeclared unit/min/max so output satisfies the canonical DD's numeric-conformance rules.

This is the bridge described in #209: it lets the importer family (XSD, JSON Schema, OWL, RDFS, SQL DDL, EML) reach the DD-shaped consumers — the inverse of the adapter ecosystem (#202) and a feeder for the enrichment pipeline (#190/#192). SchemaView-based, consistent with the enricher (#214); linkml-map is impractical here (metamodel source; enum/inheritance hit linkml-map#236/#237).

Full suite passes (162 passed, 3 skipped, 9 xfailed); deptry clean. New: 11 tests in tests/test_utils/test_extract_dd.py.