### PR TITLE
Import SchemaBuilder from linkml_runtime

### DIFF
--- a/schema_automator/generalizers/pandas_generalizer.py
+++ b/schema_automator/generalizers/pandas_generalizer.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pandera as pa
 from dataclasses import dataclass
 
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml.utils.schema_fixer import SchemaFixer
 from linkml_runtime.linkml_model import SchemaDefinition, ClassDefinition, SlotDefinition
 from pandera import Column

--- a/schema_automator/importers/cadsr_import_engine.py
+++ b/schema_automator/importers/cadsr_import_engine.py
@@ -9,7 +9,7 @@ from typing import Union, Dict, Tuple, List, Any, Optional, Iterable, Iterator
 
 from dataclasses import dataclass
 
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.linkml_model import Annotation
 from linkml_runtime.linkml_model.meta import SchemaDefinition, SlotDefinition, EnumDefinition, \
     PermissibleValue, UniqueKey, ClassDefinition

--- a/schema_automator/importers/frictionless_import_engine.py
+++ b/schema_automator/importers/frictionless_import_engine.py
@@ -3,7 +3,7 @@ from typing import Union, Dict, Tuple, List, Any, Optional
 
 from dataclasses import dataclass
 
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.linkml_model.meta import SchemaDefinition, SlotDefinition, EnumDefinition, \
     PermissibleValue, UniqueKey, ClassDefinition
 from linkml_runtime.loaders import json_loader

--- a/schema_automator/importers/jsonschema_import_engine.py
+++ b/schema_automator/importers/jsonschema_import_engine.py
@@ -7,7 +7,7 @@ import yaml
 import logging
 from typing import Any, Tuple, Dict, List, Optional
 
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.linkml_model import SchemaDefinition, ClassDefinition, \
     SlotDefinition, EnumDefinition, \
     ClassDefinitionName, Prefix

--- a/schema_automator/importers/kwalify_import_engine.py
+++ b/schema_automator/importers/kwalify_import_engine.py
@@ -3,7 +3,7 @@ from typing import Union, Dict, Tuple, List, Any, Optional
 from dataclasses import dataclass
 
 import yaml
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.linkml_model.meta import SchemaDefinition, SlotDefinition, EnumDefinition, \
     PermissibleValue, UniqueKey, ClassDefinition
 from linkml_runtime.utils.formatutils import camelcase

--- a/schema_automator/importers/rdfs_import_engine.py
+++ b/schema_automator/importers/rdfs_import_engine.py
@@ -6,7 +6,7 @@ from collections import defaultdict, Counter
 import warnings
 
 from jsonasobj2 import JsonObj
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime import SchemaView
 from linkml_runtime.linkml_model import (
     SchemaDefinition,

--- a/schema_automator/importers/sql_import_engine.py
+++ b/schema_automator/importers/sql_import_engine.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from typing import Union, Dict, Tuple, List, Any, Type
 
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.linkml_model import SchemaDefinition, SlotDefinition
 
 from dataclasses import dataclass

--- a/schema_automator/importers/xsd_import_engine.py
+++ b/schema_automator/importers/xsd_import_engine.py
@@ -4,7 +4,7 @@ import re
 from types import GenericAlias
 from typing import Any, Iterable, Type, cast, TypeVar
 from urllib.parse import urljoin
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.linkml_model import (
     SchemaDefinition,
     SlotDefinition,

--- a/tests/test_annotators/test_bioportal_schema_annotator.py
+++ b/tests/test_annotators/test_bioportal_schema_annotator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import unittest
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SchemaDefinition, EnumDefinition, PermissibleValue
 from oaklib.implementations import BioPortalImplementation

--- a/tests/test_annotators/test_lov_schema_annotator.py
+++ b/tests/test_annotators/test_lov_schema_annotator.py
@@ -4,7 +4,7 @@ import logging
 import unittest
 import os
 import yaml
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SchemaDefinition, EnumDefinition, PermissibleValue
 from oaklib import OntologyResource

--- a/tests/test_annotators/test_schema_enricher.py
+++ b/tests/test_annotators/test_schema_enricher.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import unittest
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model import SchemaDefinition, EnumDefinition, PermissibleValue
 from oaklib.implementations import BioPortalImplementation

--- a/tests/test_importers/test_sql_importer.py
+++ b/tests/test_importers/test_sql_importer.py
@@ -7,7 +7,7 @@ import os
 import yaml
 from linkml.generators.pythongen import PythonGenerator
 from linkml.utils import sqlutils
-from linkml.utils.schema_builder import SchemaBuilder
+from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml.utils.sqlutils import SQLStore
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import yaml_dumper


### PR DESCRIPTION
`linkml` deprecated the `linkml.utils.schema_builder` re-export in 1.11 and removes it in 1.12. Our pin is `linkml >= 1.10.0, < 2`, so a 1.12 release would break fresh installs — the deprecation warning already fires on every `schemauto` invocation.

Swaps the import in 8 modules and 4 tests. `linkml.utils.schema_builder.SchemaBuilder is linkml_runtime.utils.schema_builder.SchemaBuilder` today, so behaviour is unchanged.

No pin change needed: `linkml_runtime/utils/schema_builder.py` ships the full API (`add_class`, `add_slot`, `set_slot`, `add_enum`, `add_prefix`, `add_imports`, `add_defaults`, `add_type`, `as_dict`) as far back as linkml-runtime 1.10.0, which is our declared floor — checked against the 1.10.0 wheel.

Full suite green (254 passed, 3 skipped), and importing `schema_automator.cli` now raises zero `schema_builder` deprecation warnings.