### PR TITLE
Publish to PyPI on release published, not created

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -2,7 +2,8 @@ name: Publish Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
The publish workflow triggers on `release: types: [created]`, which does not fire for draft releases. Per GitHub's docs: *"Workflows are not triggered for the `created`, `edited`, or `deleted` activity types for draft releases. When you create your release through the GitHub UI, your release may automatically be saved as a draft."*

So the normal UI flow — create release, land on a draft, hit Publish — never triggers a PyPI publish. `published` fires when a draft goes live, and also for a release created already-published, so it covers both paths.

Also adds `workflow_dispatch` as a manual retry hatch for when a publish fails after the release is already out, since you can't re-fire the release event without deleting and recreating the release.