### PR TITLE
Bump pypi-publish action to v1.14.2

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -27,7 +27,7 @@ jobs:
         run: uv build
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
The `v0.5.7-rc1` publish [failed](https://github.com/linkml/schema-automator/actions/runs/32899821551) at the publish action's pre-upload `twine check`:

```
Checking dist/schema_automator-0.5.7rc1-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

The trigger, the build, and the derived version (`0.5.7rc1`) were all correct — hatchling is unpinned and current versions emit `Metadata-Version: 2.5`, which the Twine bundled in `v1.14.0` (Apr 2026) doesn't recognise. v0.5.6 published fine in July, before that shift.

[v1.14.2's release notes](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2) address it directly: *"update of Twine to v7 that we use internally. This version will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI."*

Nothing was uploaded, so no PyPI state to clean up.