### PR TITLE
Fix jsonschema importer dropping minimum/maximum, and import pattern

### DIFF
--- a/schema_automator/importers/jsonschema_import_engine.py
+++ b/schema_automator/importers/jsonschema_import_engine.py
@@ -272,6 +272,7 @@ class JsonSchemaImportEngine(ImportEngine):
             s.range = 'integer'
             self.translate_numeric_constraints(obj, s)
         elif t == 'string':
+            s.pattern = obj.get('pattern', None)
             if 'enum' in obj:
                 pvs = obj['enum']
                 if self.use_attributes and class_name:

--- a/schema_automator/importers/jsonschema_import_engine.py
+++ b/schema_automator/importers/jsonschema_import_engine.py
@@ -262,14 +262,15 @@ class JsonSchemaImportEngine(ImportEngine):
                 raise ValueError(f'Cannot translate array {name} {obj}')
         elif t == 'number':
             s.range = 'float'
+            self.translate_numeric_constraints(obj, s)
         elif t == 'boolean':
             s.range = 'boolean'
         elif t == 'float':
             s.range = 'float'
+            self.translate_numeric_constraints(obj, s)
         elif t == 'integer':
             s.range = 'integer'
-            s.minimum_value = obj.get('minimum_value', None)
-            s.maximum_value = obj.get('maximum_value', None)
+            self.translate_numeric_constraints(obj, s)
         elif t == 'string':
             if 'enum' in obj:
                 pvs = obj['enum']
@@ -287,6 +288,64 @@ class JsonSchemaImportEngine(ImportEngine):
         if not self.use_attributes:
             schema.slots[s.name] = s
         return s
+
+    def translate_numeric_constraints(self, obj: Dict, slot: SlotDefinition) -> None:
+        """
+        Translates jsonschema numeric range keywords onto a slot
+
+        LinkML ``minimum_value``/``maximum_value`` are always inclusive, so an exclusive
+        jsonschema bound is converted to the equivalent inclusive one. That conversion is
+        exact for integers, where "greater than 0" is simply "at least 1". Floats have no
+        equivalent, so the bound is widened to the inclusive one and a warning is logged.
+
+        Both spellings of exclusivity are accepted: the draft-4 form, where
+        ``exclusiveMinimum`` is a boolean making ``minimum`` exclusive, and the draft-6
+        and later form, where ``exclusiveMinimum`` is itself a number. The latter turns up
+        on integers more often than hand-written schemas would suggest, since generators
+        such as pydantic map ``gt``/``lt`` onto it regardless of the type.
+
+        :param obj: jsonschema object for a numeric property
+        :param slot: slot to be modified in place
+        """
+        is_integer = obj.get('type', None) == 'integer'
+
+        minimum = obj.get('minimum', None)
+        exclusive_minimum = obj.get('exclusiveMinimum', None)
+        if isinstance(exclusive_minimum, bool):
+            # draft-4: the boolean makes `minimum` itself exclusive
+            exclusive_minimum, minimum = (minimum, None) if exclusive_minimum else (None, minimum)
+        if exclusive_minimum is not None:
+            if is_integer:
+                exclusive_minimum = int(exclusive_minimum) + 1
+            else:
+                logging.warning(
+                    f'Exclusive minimum {exclusive_minimum} on non-integer slot '
+                    f'{slot.name} treated as inclusive'
+                )
+            # a lower bound is tighter the larger it is
+            if minimum is None or exclusive_minimum > minimum:
+                minimum = exclusive_minimum
+        if minimum is not None:
+            slot.minimum_value = minimum
+
+        maximum = obj.get('maximum', None)
+        exclusive_maximum = obj.get('exclusiveMaximum', None)
+        if isinstance(exclusive_maximum, bool):
+            # draft-4: the boolean makes `maximum` itself exclusive
+            exclusive_maximum, maximum = (maximum, None) if exclusive_maximum else (None, maximum)
+        if exclusive_maximum is not None:
+            if is_integer:
+                exclusive_maximum = int(exclusive_maximum) - 1
+            else:
+                logging.warning(
+                    f'Exclusive maximum {exclusive_maximum} on non-integer slot '
+                    f'{slot.name} treated as inclusive'
+                )
+            # an upper bound is tighter the smaller it is
+            if maximum is None or exclusive_maximum < maximum:
+                maximum = exclusive_maximum
+        if maximum is not None:
+            slot.maximum_value = maximum
 
     def _enum_from_ontology_extension(self, slot: SlotDefinition, js_obj: dict, name: str, class_name: str = None):
         gr = js_obj.get("graph_restriction", None)

--- a/tests/test_importers/test_jsonschema_importer.py
+++ b/tests/test_importers/test_jsonschema_importer.py
@@ -4,9 +4,12 @@
 
 import unittest
 import os
+
+import pytest
 from pathlib import Path
 
 from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model import SchemaDefinition
 from linkml_runtime.utils.compile_python import compile_python
 
 from schema_automator.importers.jsonschema_import_engine import JsonSchemaImportEngine
@@ -19,6 +22,45 @@ from tests import INPUT_DIR, OUTPUT_DIR
 
 #PP = os.path.join(INPUT_DIR, 'phenopackets/phenopackets.schema.json')
 #OUTSCHEMA = os.path.join(OUTPUT_DIR, 'phenopackets.yaml')
+
+
+@pytest.mark.parametrize('js_obj,expected', [
+    pytest.param({'type': 'integer', 'minimum': 0, 'maximum': 10}, (0, 10),
+                 id='inclusive_integer'),
+    pytest.param({'type': 'number', 'minimum': 0.01, 'maximum': 100}, (0.01, 100),
+                 id='inclusive_number'),
+    # draft-6 and later: exclusive bounds are numbers
+    pytest.param({'type': 'integer', 'exclusiveMinimum': 0, 'exclusiveMaximum': 10}, (1, 9),
+                 id='exclusive_integer'),
+    # the shape pydantic emits for `Field(gt=0, lt=100)` on an int
+    pytest.param({'type': 'integer', 'exclusiveMinimum': 0, 'exclusiveMaximum': 100}, (1, 99),
+                 id='pydantic_style'),
+    # draft-4: exclusive bounds are booleans modifying minimum/maximum
+    pytest.param({'type': 'integer', 'minimum': 0, 'maximum': 10,
+                  'exclusiveMinimum': True, 'exclusiveMaximum': True}, (1, 9),
+                 id='exclusive_integer_draft4'),
+    # draft-4: a false flag leaves minimum/maximum inclusive
+    pytest.param({'type': 'integer', 'minimum': 0, 'maximum': 10,
+                  'exclusiveMinimum': False, 'exclusiveMaximum': False}, (0, 10),
+                 id='inclusive_integer_draft4'),
+    # where both forms are present the tighter bound wins
+    pytest.param({'type': 'integer', 'minimum': 5, 'exclusiveMinimum': 1}, (5, None),
+                 id='inclusive_is_tighter'),
+    pytest.param({'type': 'integer', 'minimum': 1, 'exclusiveMinimum': 5}, (6, None),
+                 id='exclusive_is_tighter'),
+    pytest.param({'type': 'integer', 'maximum': 20, 'exclusiveMaximum': 5}, (None, 4),
+                 id='exclusive_is_tighter_maximum'),
+    # linkml has no exclusive bounds, so a float one is approximated as inclusive
+    pytest.param({'type': 'number', 'exclusiveMinimum': 0.0, 'maximum': 1.0}, (0.0, 1.0),
+                 id='exclusive_number'),
+    pytest.param({'type': 'integer'}, (None, None), id='unconstrained'),
+])
+def test_numeric_constraints(js_obj, expected):
+    """minimum/maximum (and their exclusive variants) become minimum_value/maximum_value."""
+    ie = JsonSchemaImportEngine()
+    ie.schema = SchemaDefinition(id='https://example.org/test', name='test')
+    slot = ie.translate_property(js_obj, 'test_slot')
+    assert expected == (slot.minimum_value, slot.maximum_value)
 
 
 class TestJsonSchemaImporter(unittest.TestCase):
@@ -95,6 +137,16 @@ class TestJsonSchemaImporter(unittest.TestCase):
         self.assertIn('active', schema.enums['activity_status_options'].permissible_values)
         self.assertIn('activity_status', schema.slots)
         self.assertEqual('activity_status_options', schema.slots['activity_status'].range)
+
+    def test_hca_numeric_constraints(self):
+        """Bounds on a `number` property survive a full conversion."""
+        ie = JsonSchemaImportEngine(use_attributes=True)
+        path = Path(INPUT_DIR) / "hca" / "module" / "biomaterial" / "human_specific.json"
+        schema = ie.convert(str(path), name="human_specific")
+        bmi = schema.classes["HumanSpecific"].attributes["body_mass_index"]
+        self.assertEqual("float", bmi.range)
+        self.assertEqual(5, bmi.minimum_value)
+        self.assertEqual(100, bmi.maximum_value)
 
     def test_import_hca_project(self):
         """This also tests the ability to import a whole project.

--- a/tests/test_importers/test_jsonschema_importer.py
+++ b/tests/test_importers/test_jsonschema_importer.py
@@ -63,6 +63,23 @@ def test_numeric_constraints(js_obj, expected):
     assert expected == (slot.minimum_value, slot.maximum_value)
 
 
+@pytest.mark.parametrize('js_obj,expected', [
+    pytest.param({'type': 'string', 'pattern': '^[0-9]{4}$'}, '^[0-9]{4}$', id='pattern'),
+    pytest.param({'type': 'string'}, None, id='no_pattern'),
+    # a constrained enum still records its pattern
+    pytest.param({'type': 'string', 'enum': ['a1', 'b2'], 'pattern': '^[ab][0-9]$'},
+                 '^[ab][0-9]$', id='pattern_with_enum'),
+    # pattern is a string-only keyword and is ignored elsewhere
+    pytest.param({'type': 'integer', 'pattern': '^[0-9]+$'}, None, id='pattern_on_integer'),
+])
+def test_string_pattern(js_obj, expected):
+    """A jsonschema `pattern` becomes the linkml `pattern` on the slot."""
+    ie = JsonSchemaImportEngine()
+    ie.schema = SchemaDefinition(id='https://example.org/test', name='test')
+    slot = ie.translate_property(js_obj, 'test_slot')
+    assert expected == slot.pattern
+
+
 class TestJsonSchemaImporter(unittest.TestCase):
     """JSONSchema """
 
@@ -147,6 +164,14 @@ class TestJsonSchemaImporter(unittest.TestCase):
         self.assertEqual("float", bmi.range)
         self.assertEqual(5, bmi.minimum_value)
         self.assertEqual(100, bmi.maximum_value)
+
+    def test_hca_string_pattern(self):
+        """A `pattern` survives a full conversion."""
+        ie = JsonSchemaImportEngine(use_attributes=True)
+        path = Path(INPUT_DIR) / "hca" / "module" / "biomaterial" / "human_specific.json"
+        schema = ie.convert(str(path), name="human_specific")
+        version = schema.classes["HumanSpecific"].attributes["schema_version"]
+        self.assertEqual("^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$", version.pattern)
 
     def test_import_hca_project(self):
         """This also tests the ability to import a whole project.


### PR DESCRIPTION
Fixes #226 
  
Fixing json schema importer to reads `minimum`/`maximum`, for `number` and `float` as well as `integer`.

Also handled:

-  Exclusive bounds:  in both the draft-4 spelling (`exclusiveMinimum` is a boolean modifying `minimum`) and draft-6+ (it is a number). LinkML's `minimum_value`/`maximum_value` are inclusive-only, so these are converted — exactly for integers, where "greater than 0" is "at least 1", and with a logged warning for floats, which have no exact equivalent. This matters in practice because pydantic maps `Field(gt=0, lt=100)` onto the exclusive keywords regardless of type.
- `pattern` on string slots, which maps 1:1 onto LinkML's `pattern` and
    round-trips verbatim through `JsonSchemaGenerator`.
